### PR TITLE
add config field to API call params

### DIFF
--- a/cpp/linux/numberPlate.cpp
+++ b/cpp/linux/numberPlate.cpp
@@ -23,10 +23,10 @@ namespace
 }
 
 Json::Value sendRequest(string auth_token, string fileName) {
-	
+
 	curl_global_init(CURL_GLOBAL_ALL);
 
-	
+
 	curl_off_t speed_upload, total_time;
 	curl_mime *form = NULL;
 	curl_mimepart *field = NULL;
@@ -42,6 +42,13 @@ Json::Value sendRequest(string auth_token, string fileName) {
 	field = curl_mime_addpart(form);
 	curl_mime_name(field, "upload");
 	curl_mime_filedata(field, fileName.c_str());
+
+	// Add more fields
+	curl_mimepart *part = NULL;
+	part = curl_mime_addpart(form);
+	curl_mime_name(part, "config");
+	curl_mime_data(part, "{\"mode\":\"redaction\"}", CURL_ZERO_TERMINATED);
+
 	curl_easy_setopt(hnd, CURLOPT_MIMEPOST, form);
 
 	struct curl_slist *headers = NULL;
@@ -74,7 +81,7 @@ Json::Value sendRequest(string auth_token, string fileName) {
 			(total_time / 1000000), (long)(total_time % 1000000));
 	}
 
-	curl_easy_cleanup(hnd); 
+	curl_easy_cleanup(hnd);
 	curl_mime_free(form);
 
 	Json::Value jsonData;

--- a/cpp/linux/numberPlate.cpp
+++ b/cpp/linux/numberPlate.cpp
@@ -22,7 +22,7 @@ namespace
 	}
 }
 
-Json::Value sendRequest(string auth_token, string fileName) {
+Json::Value sendRequest(string auth_token, string fileName, string mode) {
 
 	curl_global_init(CURL_GLOBAL_ALL);
 
@@ -44,10 +44,21 @@ Json::Value sendRequest(string auth_token, string fileName) {
 	curl_mime_filedata(field, fileName.c_str());
 
 	// Add more fields
-	curl_mimepart *part = NULL;
-	part = curl_mime_addpart(form);
-	curl_mime_name(part, "config");
-	curl_mime_data(part, "{\"mode\":\"redaction\"}", CURL_ZERO_TERMINATED);
+	// config mode
+	if(mode.length()) {
+        curl_mimepart *part = NULL;
+        part = curl_mime_addpart(form);
+        curl_mime_name(part, "config");
+
+        if (strcmp(mode.c_str(),"redacted") == 0){
+            curl_mime_data(part, "{\"mode\":\"redacted\"}", CURL_ZERO_TERMINATED);
+        } else if (strcmp(mode.c_str(),"fast") == 0){
+            curl_mime_data(part, "{\"mode\":\"fast\"}", CURL_ZERO_TERMINATED);
+        } else{
+            cout << "Unknown config mode : "+mode+"\n Valid Options: fast, redacted\n";
+            exit(1);
+        }
+    }
 
 	curl_easy_setopt(hnd, CURLOPT_MIMEPOST, form);
 
@@ -106,11 +117,11 @@ int main(int argc, char *argv[])
 {
 	string token = "MY_API_KEY";
 	Json::Value data;
-	if (argc == 2) {
-		data = sendRequest(token, argv[1]);
+	if (argc >= 2) {
+		data = sendRequest(token, argv[1], argv[2]);
 	}
 	else {
-		cout << "Error:Invalid Arguments!\nUsage: program.exe <Image>";
+		cout << "Error:Invalid Arguments!\nUsage: program.exe <Image>\n program.exe <Image> <ConfigMode>";
 	}
 
 	ofstream file;

--- a/cpp/windows/ConsoleApplication2/ConsoleApplication2.cpp
+++ b/cpp/windows/ConsoleApplication2/ConsoleApplication2.cpp
@@ -27,10 +27,10 @@ namespace
 }
 
 Json::Value sendRequest(string auth_token, string fileName) {
-	
+
 	curl_global_init(CURL_GLOBAL_ALL);
 
-	
+
 	curl_off_t speed_upload, total_time;
 	curl_mime *form = NULL;
 	curl_mimepart *field = NULL;
@@ -46,6 +46,13 @@ Json::Value sendRequest(string auth_token, string fileName) {
 	field = curl_mime_addpart(form);
 	curl_mime_name(field, "upload");
 	curl_mime_filedata(field, fileName.c_str());
+
+	// Add more fields
+	curl_mimepart *part = NULL;
+	part = curl_mime_addpart(form);
+	curl_mime_name(part, "config");
+	curl_mime_data(part, "{\"mode\":\"redaction\"}", CURL_ZERO_TERMINATED);
+
 	curl_easy_setopt(hnd, CURLOPT_MIMEPOST, form);
 
 	struct curl_slist *headers = NULL;
@@ -78,7 +85,7 @@ Json::Value sendRequest(string auth_token, string fileName) {
 			(total_time / 1000000), (long)(total_time % 1000000));
 	}
 
-	curl_easy_cleanup(hnd); 
+	curl_easy_cleanup(hnd);
 	curl_mime_free(form);
 
 	Json::Value jsonData;

--- a/cpp/windows/ConsoleApplication2/ConsoleApplication2.cpp
+++ b/cpp/windows/ConsoleApplication2/ConsoleApplication2.cpp
@@ -26,7 +26,7 @@ namespace
 	}
 }
 
-Json::Value sendRequest(string auth_token, string fileName) {
+Json::Value sendRequest(string auth_token, string fileName, string mode) {
 
 	curl_global_init(CURL_GLOBAL_ALL);
 
@@ -48,10 +48,21 @@ Json::Value sendRequest(string auth_token, string fileName) {
 	curl_mime_filedata(field, fileName.c_str());
 
 	// Add more fields
-	curl_mimepart *part = NULL;
-	part = curl_mime_addpart(form);
-	curl_mime_name(part, "config");
-	curl_mime_data(part, "{\"mode\":\"redaction\"}", CURL_ZERO_TERMINATED);
+	// config mode
+	if(mode.length()) {
+		curl_mimepart *part = NULL;
+		part = curl_mime_addpart(form);
+		curl_mime_name(part, "config");
+
+		if (strcmp(mode.c_str(),"redacted") == 0){
+			curl_mime_data(part, "{\"mode\":\"redacted\"}", CURL_ZERO_TERMINATED);
+		} else if (strcmp(mode.c_str(),"fast") == 0){
+			curl_mime_data(part, "{\"mode\":\"fast\"}", CURL_ZERO_TERMINATED);
+		} else{
+			cout << "Unknown config mode : "+mode+"\n Valid Options: fast, redacted\n";
+			exit(1);
+		}
+	}
 
 	curl_easy_setopt(hnd, CURLOPT_MIMEPOST, form);
 
@@ -110,11 +121,11 @@ int main(int argc, char *argv[])
 {
 	string token = "MY_API_KEY";
 	Json::Value data;
-	if (argc == 2) {
-		data = sendRequest(token, argv[1]);
+	if (argc >= 2) {
+		data = sendRequest(token, argv[1], argv[2]);
 	}
 	else {
-		cout << "Error:Invalid Arguments!\nUsage: program.exe <Image>";
+		cout << "Error:Invalid Arguments!\nUsage: program.exe <Image>\n program.exe <Image> <ConfigMode>";
 	}
 
 	ofstream file;


### PR DESCRIPTION
Added an extra param **mode** apart from only `upload` as an example and easier starting point to users who need to cutomize params