### PR TITLE
Refactor: FrontRear statuses and logging

### DIFF
--- a/webhooks/middleware/protocols/config/front_rear_config.json
+++ b/webhooks/middleware/protocols/config/front_rear_config.json
@@ -35,8 +35,8 @@
   },
   "front_rear_csv_path": "protocols/config/front_rear.csv",
   "parkpow": {
-    "alert_endpoint": "<alert_endpoint>",
-    "webhook_endpoint": "<webhook_endpoint>"
+    "alert_endpoint": "https://app.parkpow.com/api/v1/trigger-alert/",
+    "webhook_endpoint": "https://app.parkpow.com/api/v1/webhook-receiver/"
   },
   "alerts": {
     "plate_mismatch": {

--- a/webhooks/middleware/protocols/front_rear.py
+++ b/webhooks/middleware/protocols/front_rear.py
@@ -826,8 +826,8 @@ def _process_events(
 
     data_to_forward = rear_event if rear_event else front_event
     if not data_to_forward:
-        camera_pair = f"{_short(front_camera_id)} / {_short(rear_camera_id)}"
         is_solo = not (front_camera_id and rear_camera_id)
+        camera_pair = f"{_short(front_camera_id)}{'' if is_solo else ' / '}{_short(rear_camera_id)}"
         logging.warning(
             f"No event data to forward for {'camera' if is_solo else 'pair'} {camera_pair}"
         )
@@ -836,7 +836,7 @@ def _process_events(
     visit_id = _forward_to_parkpow(data_to_forward)
     if not visit_id:
         is_solo = not front_camera_id or not rear_camera_id
-        camera_pair = f"{_short(front_camera_id)}{' / ' if not is_solo else ''}{_short(rear_camera_id)}"
+        camera_pair = f"{_short(front_camera_id)}{'' if is_solo else ' / '}{_short(rear_camera_id)}"
         logging.error(
             f"Failed to create visit in ParkPow for {'camera' if is_solo else 'pair'} {camera_pair}, skipping alerts"
         )
@@ -1103,7 +1103,7 @@ def process_request(
                 logging.info(f"Processing solo camera {_short(pair.solo_camera_id)}")
             else:
                 logging.info(
-                    f"Processing camera pair {_short(pair.front)}/{_short(pair.rear)}"
+                    f"Processing camera pair {_short(pair.front)} / {_short(pair.rear)}"
                 )
 
             try:

--- a/webhooks/middleware/protocols/front_rear.py
+++ b/webhooks/middleware/protocols/front_rear.py
@@ -17,6 +17,7 @@ Alerts:
 """
 
 import asyncio
+import concurrent.futures
 import csv
 import hmac
 import json
@@ -649,6 +650,8 @@ def _forward_to_parkpow(event: CameraEvent) -> int | None:
         return future.result(timeout=15)
     except ParkPowError:
         raise
+    except concurrent.futures.TimeoutError as e:
+        raise ParkPowError(503, f"Timed out waiting for ParkPow response: {e}") from e
     except Exception as e:
         logging.error(f"Failed to forward to ParkPow: {e}")
         return None

--- a/webhooks/middleware/protocols/front_rear.py
+++ b/webhooks/middleware/protocols/front_rear.py
@@ -920,7 +920,7 @@ def _authenticate_request(json_data: dict[str, Any]) -> tuple[str, int] | None:
         return "FrontRear - Unauthorized: Malformed Authorization header", 401
 
     if not any(hmac.compare_digest(token, v_token) for v_token in _stream_api_tokens):
-        return "FrontRear - Unauthorized: Invalid token", 403
+        return "FrontRear - Forbidden: Invalid token", 403
 
     return None
 

--- a/webhooks/middleware/protocols/front_rear.py
+++ b/webhooks/middleware/protocols/front_rear.py
@@ -264,6 +264,12 @@ def initialize() -> None:
     _parkpow_token = token
     _stream_api_tokens = [t.strip() for t in stream_tokens_env.split(",") if t.strip()]
 
+    if not _stream_api_tokens:
+        logging.error("STREAM_API_TOKENS has no valid tokens after parsing")
+        raise ValueError(
+            "Front-Rear middleware requires at least one valid token in STREAM_API_TOKENS"
+        )
+
     _loop = asyncio.new_event_loop()
     _loop_thread = threading.Thread(target=_run_event_loop, args=(_loop,), daemon=True)
     _loop_thread.start()
@@ -904,9 +910,6 @@ def _stream_response(
 
 def _authenticate_request(json_data: dict[str, Any]) -> tuple[str, int] | None:
     """Authenticate webhook request. Returns None if valid, or (error_msg, status) tuple."""
-    if not _stream_api_tokens:
-        return "FrontRear - Unauthorized: Authentication not configured", 401
-
     auth_header = get_header("Authorization", json_data)
     if not auth_header:
         return "FrontRear - Unauthorized: Missing Authorization header", 401

--- a/webhooks/middleware/protocols/front_rear.py
+++ b/webhooks/middleware/protocols/front_rear.py
@@ -797,10 +797,17 @@ def _process_events(
 
     visit_id = _forward_to_parkpow(data_to_forward)
     if visit_id == -1:
-        logging.warning(
-            "ParkPow rejected visit creation due to low confidence scores, skipping alerts"
+        is_solo = not front_camera_id or not rear_camera_id
+        camera_pair = f"{_short(front_camera_id)}{' / ' if not is_solo else ''}{_short(rear_camera_id)}"
+        plates = (
+            f"front={front_plate}, rear={rear_plate}"
+            if not is_solo
+            else f"plate={front_plate or rear_plate}"
         )
-        return None
+        logging.warning(
+            f"ParkPow rejected visit for {'camera' if is_solo else 'pair'} {camera_pair} ({plates}) - confidence scores too low"
+        )
+        return -1
 
     if not visit_id:
         is_solo = not front_camera_id or not rear_camera_id
@@ -1063,9 +1070,13 @@ def process_request(
                     f"Processing camera pair {_short(pair.front)}/{_short(pair.rear)}"
                 )
 
-            _process_camera_pair(pair)
+            visit_id = _process_camera_pair(pair)
             pair.front_event = None
             pair.rear_event = None
+
+            if visit_id == -1:
+                return "Visit rejected: confidence scores too low", 422
+
             return "Processed camera pair", 200
 
     if not pair.is_solo:

--- a/webhooks/middleware/protocols/front_rear.py
+++ b/webhooks/middleware/protocols/front_rear.py
@@ -1117,7 +1117,9 @@ def process_request(
             pair.rear_event = None
 
             if visit_id is None:
-                return _stream_response("FrontRear - Internal error", 424, camera_id)
+                return _stream_response(
+                    "FrontRear - Internal error (null visit_id)", 424, camera_id
+                )
 
             return _stream_response("FrontRear - Processed camera pair", 200, camera_id)
 

--- a/webhooks/middleware/protocols/front_rear.py
+++ b/webhooks/middleware/protocols/front_rear.py
@@ -329,9 +329,9 @@ def _cleanup_task_loop() -> None:
         time.sleep(cleanup_interval)
 
 
-def _short(camera_id: str | None) -> str | None:
+def _short(camera_id: str | None) -> str:
     """Helper to shorten camera ID for logging."""
-    return f"...{camera_id[-12:]}" if camera_id and len(camera_id) >= 60 else camera_id
+    return f"...{camera_id[-12:]}" if camera_id else ""
 
 
 def _cleanup_expired_events() -> None:
@@ -373,7 +373,7 @@ def _cleanup_expired_events() -> None:
         assert missing_camera is not None
 
         logging.warning(
-            f"Unpaired event for {pair.description} ({_short(camera_id)}) expired after {age:.1f}s, {_short(missing_camera)} may be offline, processing single camera event"
+            f"Unpaired event for {pair.description} ({_short(camera_id)}) expired after {age:.1f}s, {missing_camera} may be offline, processing single camera event"
         )
 
         visit_id = _process_camera_pair(pair)
@@ -634,7 +634,7 @@ def _check_no_rear_plate_alert(
 ) -> bool:
     """Check and send no rear plate alert. Returns True if should skip further processing."""
     if rear_camera_id and not rear_plate and rear_event:
-        logging.warning(f"No rear plate detected for {_short(rear_camera_id)}")
+        logging.warning(f"No rear plate detected for {rear_camera_id}")
         _send_alert(
             alert_type="no_rear_plate",
             visit_id=visit_id,
@@ -791,7 +791,7 @@ def _process_events(
         camera_pair = f"{_short(front_camera_id)} / {_short(rear_camera_id)}"
         is_solo = not (front_camera_id and rear_camera_id)
         logging.warning(
-            f"No event data to forward for {'solo camera' if is_solo else 'pair'} {camera_pair}"
+            f"No event data to forward for {'camera' if is_solo else 'pair'} {camera_pair}"
         )
         return None
 
@@ -942,7 +942,7 @@ def _handle_event_overwrite(
         if not pair.is_solo:
             logging.warning(
                 f"Overwriting unpaired event from {_short(camera_id)} (age: {age:.1f}s, old plate: {old_plate}) - "
-                f"new vehicle ({new_plate}) detected before pair completed, {_short(missing_camera)} may be offline"
+                f"new vehicle ({new_plate}) detected before pair completed, {camera_id} may be offline"
             )
 
         old_front_event = old_event if is_front else None
@@ -1050,7 +1050,7 @@ def process_request(
                 visit_id=visit_id,
                 plate=None,
                 camera_id=missing_camera_id,
-                message=f"Camera {_short(missing_camera_id)} may be offline - unpaired event overwritten after {overwrite_age:.1f}s",
+                message=f"Camera {camera_id} may be offline - unpaired event overwritten after {overwrite_age:.1f}s",
                 event_data=overwrite_old_event,
             )
 

--- a/webhooks/middleware/protocols/front_rear.py
+++ b/webhooks/middleware/protocols/front_rear.py
@@ -967,7 +967,7 @@ def _handle_event_overwrite(
         if not pair.is_solo:
             logging.warning(
                 f"Overwriting unpaired event from {_short(camera_id)} (age: {age:.1f}s, old plate: {old_plate}) - "
-                f"new vehicle ({new_plate}) detected before pair completed, {camera_id} may be offline"
+                f"new vehicle ({new_plate}) detected before pair completed, {missing_camera} may be offline"
             )
 
         old_front_event = old_event if is_front else None
@@ -1082,7 +1082,7 @@ def process_request(
                 visit_id=visit_id,
                 plate=None,
                 camera_id=missing_camera_id,
-                message=f"Camera {camera_id} may be offline - unpaired event overwritten after {overwrite_age:.1f}s",
+                message=f"Camera {missing_camera_id} may be offline - unpaired event overwritten after {overwrite_age:.1f}s",
                 event_data=overwrite_old_event,
             )
 

--- a/webhooks/middleware/protocols/front_rear.py
+++ b/webhooks/middleware/protocols/front_rear.py
@@ -63,6 +63,21 @@ class CameraEvent:
 
 
 @dataclass
+class AlertCheckContext:
+    """Shared payload used by alert-check helper functions."""
+
+    front_camera_id: str | None
+    rear_camera_id: str | None
+    front_plate: str | None
+    rear_plate: str | None
+    front_event: CameraEvent | None
+    rear_event: CameraEvent | None
+    detected_make_model: str | None
+    make_model_score: float
+    visit_id: int
+
+
+@dataclass
 class CameraPair:
     """Paired front/rear camera configuration with event buffering."""
 
@@ -614,103 +629,75 @@ def _forward_to_parkpow(event: CameraEvent) -> int | None:
         return None
 
 
-def _check_no_rear_plate_alert(
-    rear_camera_id: str | None,
-    rear_plate: str | None,
-    rear_event: CameraEvent | None,
-    front_plate: str | None,
-    visit_id: int,
-) -> bool:
+def _check_no_rear_plate_alert(ctx: AlertCheckContext) -> bool:
     """Check and send no rear plate alert. Returns True if should skip further processing."""
-    if rear_camera_id and not rear_plate and rear_event:
-        logging.warning(f"No rear plate detected for {rear_camera_id}")
+    if ctx.rear_camera_id and not ctx.rear_plate and ctx.rear_event:
+        logging.warning(f"No rear plate detected for {ctx.rear_camera_id}")
         _send_alert(
             alert_type="no_rear_plate",
-            visit_id=visit_id,
-            plate=front_plate,
-            camera_id=rear_camera_id,
-            message=f"No rear plate detected for front plate {front_plate}",
-            event_data=rear_event,
+            visit_id=ctx.visit_id,
+            plate=ctx.front_plate,
+            camera_id=ctx.rear_camera_id,
+            message=f"No rear plate detected for front plate {ctx.front_plate}",
+            event_data=ctx.rear_event,
         )
-        return not front_plate
+        return not ctx.front_plate
     return False
 
 
 def _check_plate_mismatch_alerts(
-    front_plate: str | None,
-    rear_plate: str | None,
-    front_camera_id: str | None,
-    rear_camera_id: str | None,
-    front_event: CameraEvent | None,
-    rear_event: CameraEvent | None,
-    detected_make_model: str | None,
-    make_model_score: float,
-    visit_id: int,
+    ctx: AlertCheckContext,
 ) -> tuple[bool, bool, dict[str, str] | None, dict[str, str] | None]:
     """Check and send plate mismatch alerts. Returns (front_in_db, rear_in_db, front_info, rear_info)."""
     front_in_db, front_vehicle_info = h.check_plate_in_vehicles_db(
-        front_plate, csv_vehicles
+        ctx.front_plate, csv_vehicles
     )
     rear_in_db, rear_vehicle_info = h.check_plate_in_vehicles_db(
-        rear_plate, csv_vehicles
+        ctx.rear_plate, csv_vehicles
     )
 
-    if front_plate and not front_in_db:
-        logging.warning(f"Front plate {front_plate} not found in Front-Rear database")
-        if front_camera_id:
+    if ctx.front_plate and not front_in_db:
+        logging.warning(
+            f"Front plate {ctx.front_plate} not found in Front-Rear database"
+        )
+        if ctx.front_camera_id:
             _send_alert(
                 alert_type="plate_mismatch",
-                visit_id=visit_id,
-                plate=front_plate,
-                camera_id=front_camera_id,
-                message=f"License plate {front_plate} not found in Front-Rear Vehicle Database",
-                event_data=front_event,
-                detected_make_model=detected_make_model,
-                make_model_score=make_model_score,
+                visit_id=ctx.visit_id,
+                plate=ctx.front_plate,
+                camera_id=ctx.front_camera_id,
+                message=f"License plate {ctx.front_plate} not found in Front-Rear Vehicle Database",
+                event_data=ctx.front_event,
+                detected_make_model=ctx.detected_make_model,
+                make_model_score=ctx.make_model_score,
             )
 
-    if rear_plate and not rear_in_db:
-        logging.warning(f"Rear plate {rear_plate} not found in Front-Rear database")
-        if rear_camera_id:
+    if ctx.rear_plate and not rear_in_db:
+        logging.warning(f"Rear plate {ctx.rear_plate} not found in Front-Rear database")
+        if ctx.rear_camera_id:
             _send_alert(
                 alert_type="plate_mismatch",
-                visit_id=visit_id,
-                plate=rear_plate,
-                camera_id=rear_camera_id,
-                message=f"License plate {rear_plate} not found in Front-Rear Vehicle Database",
-                event_data=rear_event,
-                detected_make_model=detected_make_model,
-                make_model_score=make_model_score,
+                visit_id=ctx.visit_id,
+                plate=ctx.rear_plate,
+                camera_id=ctx.rear_camera_id,
+                message=f"License plate {ctx.rear_plate} not found in Front-Rear Vehicle Database",
+                event_data=ctx.rear_event,
+                detected_make_model=ctx.detected_make_model,
+                make_model_score=ctx.make_model_score,
             )
 
     return front_in_db, rear_in_db, front_vehicle_info, rear_vehicle_info
 
 
 def _check_make_model_mismatch_alert(
-    rear_camera_id: str | None,
-    front_camera_id: str | None,
-    rear_plate: str | None,
-    front_plate: str | None,
-    rear_in_db: bool,
-    front_in_db: bool,
-    rear_vehicle_info: dict[str, str] | None,
-    front_vehicle_info: dict[str, str] | None,
-    detected_make_model: str | None,
-    make_model_score: float,
-    rear_event: CameraEvent | None,
-    front_event: CameraEvent | None,
-    visit_id: int,
+    ctx: AlertCheckContext,
+    reference_plate: str | None,
+    reference_vehicle_info: dict[str, str] | None,
+    alert_camera_id: str | None,
+    event_data: CameraEvent | None,
+    make_model_threshold: float,
 ) -> None:
     """Check and send make/model mismatch alert."""
-    current_config = _load_config()
-    make_model_threshold = current_config.get("thresholds", {}).get(
-        "make_model_confidence", 0.2
-    )
-    reference_plate = (
-        rear_plate if rear_in_db else (front_plate if front_in_db else None)
-    )
-    reference_vehicle_info = rear_vehicle_info if rear_in_db else front_vehicle_info
-
     if not reference_plate or not reference_vehicle_info:
         return
 
@@ -718,32 +705,27 @@ def _check_make_model_mismatch_alert(
     front_rear_model = reference_vehicle_info.get("model", "")
     front_rear_make_model = f"{front_rear_make} {front_rear_model}".strip()
     make_model_mismatch = (
-        detected_make_model and detected_make_model != front_rear_make_model
+        ctx.detected_make_model and ctx.detected_make_model != front_rear_make_model
     )
 
-    if not (make_model_mismatch and make_model_score >= make_model_threshold):
+    if not (make_model_mismatch and ctx.make_model_score >= make_model_threshold):
         return
 
-    message = f"Make/model mismatch for {reference_plate}: detected {detected_make_model} (score: {make_model_score:.2f}), expected {front_rear_make_model} from Front-Rear database"
+    message = f"Make/model mismatch for {reference_plate}: detected {ctx.detected_make_model} (score: {ctx.make_model_score:.2f}), expected {front_rear_make_model} from Front-Rear database"
 
     logging.warning(message)
-    alert_camera_id = (
-        rear_camera_id
-        if (rear_camera_id and rear_plate)
-        else (front_camera_id if front_camera_id else None)
-    )
     if not alert_camera_id:
         return
 
     _send_alert(
         alert_type="make_model_mismatch",
-        visit_id=visit_id,
+        visit_id=ctx.visit_id,
         plate=reference_plate,
         camera_id=alert_camera_id,
         message=message,
-        event_data=rear_event if rear_event else front_event,
-        detected_make_model=detected_make_model,
-        make_model_score=make_model_score,
+        event_data=event_data,
+        detected_make_model=ctx.detected_make_model,
+        make_model_score=ctx.make_model_score,
     )
 
 
@@ -778,6 +760,17 @@ def _process_events(
     detected_make_model, make_model_score = (
         h.extract_best_make_model(all_results) if all_results else (None, 0.0)
     )
+    alert_ctx = AlertCheckContext(
+        front_camera_id=front_camera_id,
+        rear_camera_id=rear_camera_id,
+        front_plate=front_plate,
+        rear_plate=rear_plate,
+        front_event=front_event,
+        rear_event=rear_event,
+        detected_make_model=detected_make_model,
+        make_model_score=make_model_score,
+        visit_id=0,
+    )
 
     data_to_forward = rear_event if rear_event else front_event
     if not data_to_forward:
@@ -796,43 +789,39 @@ def _process_events(
             f"Failed to create visit in ParkPow for {'camera' if is_solo else 'pair'} {camera_pair}, skipping alerts"
         )
         return None
+    alert_ctx.visit_id = visit_id
 
     # Alert #2: No Rear Plate Alert (only if rear camera exists and not offline)
-    if _check_no_rear_plate_alert(
-        rear_camera_id, rear_plate, rear_event, front_plate, visit_id
-    ):
+    if _check_no_rear_plate_alert(alert_ctx):
         return visit_id
 
     # Alert #1: Plate Mismatch Alert (either camera plate not in Front-Rear DB)
     front_in_db, rear_in_db, front_vehicle_info, rear_vehicle_info = (
-        _check_plate_mismatch_alerts(
-            front_plate,
-            rear_plate,
-            front_camera_id,
-            rear_camera_id,
-            front_event,
-            rear_event,
-            detected_make_model,
-            make_model_score,
-            visit_id,
-        )
+        _check_plate_mismatch_alerts(alert_ctx)
     )
 
+    reference_plate = (
+        rear_plate if rear_in_db else (front_plate if front_in_db else None)
+    )
+    reference_vehicle_info = rear_vehicle_info if rear_in_db else front_vehicle_info
+    alert_camera_id = (
+        rear_camera_id
+        if (rear_camera_id and rear_plate)
+        else (front_camera_id if front_camera_id else None)
+    )
+    event_data = rear_event if rear_event else front_event
+    current_config = _load_config()
+    make_model_threshold = current_config.get("thresholds", {}).get(
+        "make_model_confidence", 0.2
+    )
     # Alert #3: Make/Model Mismatch Alert
     _check_make_model_mismatch_alert(
-        rear_camera_id,
-        front_camera_id,
-        rear_plate,
-        front_plate,
-        rear_in_db,
-        front_in_db,
-        rear_vehicle_info,
-        front_vehicle_info,
-        detected_make_model,
-        make_model_score,
-        rear_event,
-        front_event,
-        visit_id,
+        alert_ctx,
+        reference_plate,
+        reference_vehicle_info,
+        alert_camera_id,
+        event_data,
+        make_model_threshold,
     )
 
     return visit_id

--- a/webhooks/middleware/protocols/front_rear.py
+++ b/webhooks/middleware/protocols/front_rear.py
@@ -329,6 +329,11 @@ def _cleanup_task_loop() -> None:
         time.sleep(cleanup_interval)
 
 
+def _short(camera_id: str | None) -> str | None:
+    """Helper to shorten camera ID for logging."""
+    return f"...{camera_id[-9:]}" if camera_id else None
+
+
 def _cleanup_expired_events() -> None:
     """Remove expired events from buffer to prevent memory bloat."""
     global config
@@ -365,9 +370,10 @@ def _cleanup_expired_events() -> None:
             age = time.time() - current_event.timestamp_unix
             missing_camera = pair.rear if is_front else pair.front
 
+        assert missing_camera is not None
+
         logging.warning(
-            f"Unpaired event expired from {camera_id} after {age:.1f}s - "
-            f"{missing_camera} may be offline, processing single camera event"
+            f"Unpaired event for {pair.description} ({_short(camera_id)}) expired after {age:.1f}s, {_short(missing_camera)} may be offline, processing single camera event"
         )
 
         visit_id = _process_camera_pair(pair)
@@ -591,12 +597,12 @@ async def _forward_to_parkpow_async(event: CameraEvent) -> int | None:
 
         if visit_id:
             logging.info(f"Created visit {visit_id} in ParkPow")
-            return visit_id
+            return int(visit_id)
+        elif "requires higher scores" in str(response_data).lower():
+            return -1
         else:
             logging.warning(
-                f"ParkPow response missing or invalid visit id. "
-                f"Response type: {type(response_data).__name__}, "
-                f"Content: {response_data}"
+                f"ParkPow response missing or invalid visit id: {response_data}"
             )
             return None
 
@@ -617,6 +623,135 @@ def _forward_to_parkpow(event: CameraEvent) -> int | None:
     except Exception as e:
         logging.error(f"Failed to forward to ParkPow: {e}")
         return None
+
+
+def _check_no_rear_plate_alert(
+    rear_camera_id: str | None,
+    rear_plate: str | None,
+    rear_event: CameraEvent | None,
+    front_plate: str | None,
+    visit_id: int,
+) -> bool:
+    """Check and send no rear plate alert. Returns True if should skip further processing."""
+    if rear_camera_id and not rear_plate and rear_event:
+        logging.warning(f"No rear plate detected for {_short(rear_camera_id)}")
+        _send_alert(
+            alert_type="no_rear_plate",
+            visit_id=visit_id,
+            plate=front_plate,
+            camera_id=rear_camera_id,
+            message=f"No rear plate detected for front plate {front_plate}",
+            event_data=rear_event,
+        )
+        return not front_plate
+    return False
+
+
+def _check_plate_mismatch_alerts(
+    front_plate: str | None,
+    rear_plate: str | None,
+    front_camera_id: str | None,
+    rear_camera_id: str | None,
+    front_event: CameraEvent | None,
+    rear_event: CameraEvent | None,
+    detected_make_model: str | None,
+    make_model_score: float,
+    visit_id: int,
+) -> tuple[bool, bool, dict[str, str] | None, dict[str, str] | None]:
+    """Check and send plate mismatch alerts. Returns (front_in_db, rear_in_db, front_info, rear_info)."""
+    front_in_db, front_vehicle_info = _check_plate_in_vehicles_db(front_plate)
+    rear_in_db, rear_vehicle_info = _check_plate_in_vehicles_db(rear_plate)
+
+    if front_plate and not front_in_db:
+        logging.warning(f"Front plate {front_plate} not found in Front-Rear database")
+        if front_camera_id:
+            _send_alert(
+                alert_type="plate_mismatch",
+                visit_id=visit_id,
+                plate=front_plate,
+                camera_id=front_camera_id,
+                message=f"License plate {front_plate} not found in Front-Rear Vehicle Database",
+                event_data=front_event,
+                detected_make_model=detected_make_model,
+                make_model_score=make_model_score,
+            )
+
+    if rear_plate and not rear_in_db:
+        logging.warning(f"Rear plate {rear_plate} not found in Front-Rear database")
+        if rear_camera_id:
+            _send_alert(
+                alert_type="plate_mismatch",
+                visit_id=visit_id,
+                plate=rear_plate,
+                camera_id=rear_camera_id,
+                message=f"License plate {rear_plate} not found in Front-Rear Vehicle Database",
+                event_data=rear_event,
+                detected_make_model=detected_make_model,
+                make_model_score=make_model_score,
+            )
+
+    return front_in_db, rear_in_db, front_vehicle_info, rear_vehicle_info
+
+
+def _check_make_model_mismatch_alert(
+    rear_camera_id: str | None,
+    front_camera_id: str | None,
+    rear_plate: str | None,
+    front_plate: str | None,
+    rear_in_db: bool,
+    front_in_db: bool,
+    rear_vehicle_info: dict[str, str] | None,
+    front_vehicle_info: dict[str, str] | None,
+    detected_make_model: str | None,
+    make_model_score: float,
+    rear_event: CameraEvent | None,
+    front_event: CameraEvent | None,
+    visit_id: int,
+) -> None:
+    """Check and send make/model mismatch alert."""
+    current_config = _load_config()
+    make_model_threshold = current_config.get("thresholds", {}).get(
+        "make_model_confidence", 0.2
+    )
+    reference_plate = (
+        rear_plate if rear_in_db else (front_plate if front_in_db else None)
+    )
+    reference_vehicle_info = rear_vehicle_info if rear_in_db else front_vehicle_info
+
+    if not reference_plate or not reference_vehicle_info:
+        return
+
+    front_rear_make = reference_vehicle_info.get("make", "")
+    front_rear_model = reference_vehicle_info.get("model", "")
+    front_rear_make_model = f"{front_rear_make} {front_rear_model}".strip()
+    make_model_mismatch = (
+        detected_make_model and detected_make_model != front_rear_make_model
+    )
+
+    if not (make_model_mismatch and make_model_score >= make_model_threshold):
+        return
+
+    message = f"Make/model mismatch for {reference_plate}: detected {detected_make_model} (score: {make_model_score:.2f}), expected {front_rear_make_model} from Front-Rear database"
+
+    logging.warning(message)
+    alert_camera_id = (
+        rear_camera_id
+        if (rear_camera_id and rear_plate)
+        else (front_camera_id if front_camera_id else None)
+    )
+    if not alert_camera_id:
+        return
+
+    _send_alert(
+        alert_type="make_model_mismatch",
+        visit_id=visit_id,
+        plate=reference_plate,
+        camera_id=alert_camera_id,
+        message=message,
+        event_data=rear_event if rear_event else front_event,
+        detected_make_model=detected_make_model,
+        make_model_score=make_model_score,
+    )
 
 
 def _process_events(
@@ -653,116 +788,65 @@ def _process_events(
 
     data_to_forward = rear_event if rear_event else front_event
     if not data_to_forward:
-        camera_desc = f"{front_camera_id or 'none'}/{rear_camera_id or 'none'}"
+        camera_pair = f"{_short(front_camera_id)} / {_short(rear_camera_id)}"
         is_solo = not (front_camera_id and rear_camera_id)
         logging.warning(
-            f"No event data to forward for {'solo camera' if is_solo else 'pair'} {camera_desc}"
+            f"No event data to forward for {'solo camera' if is_solo else 'pair'} {camera_pair}"
         )
         return None
 
     visit_id = _forward_to_parkpow(data_to_forward)
+    if visit_id == -1:
+        logging.warning(
+            "ParkPow rejected visit creation due to low confidence scores, skipping alerts"
+        )
+        return None
+
     if not visit_id:
-        camera_desc = f"{front_camera_id or 'none'}/{rear_camera_id or 'none'}"
-        is_solo = not (front_camera_id and rear_camera_id)
+        is_solo = not front_camera_id or not rear_camera_id
+        camera_pair = f"{_short(front_camera_id)}{' / ' if not is_solo else ''}{_short(rear_camera_id)}"
         logging.error(
-            f"Failed to create visit in ParkPow for {'solo camera' if is_solo else 'pair'} {camera_desc}, skipping alerts"
+            f"Failed to create visit in ParkPow for {'camera' if is_solo else 'pair'} {camera_pair}, skipping alerts"
         )
         return None
 
     # Alert #2: No Rear Plate Alert (only if rear camera exists and not offline)
-    if rear_camera_id and not rear_plate and rear_event:
-        logging.warning(
-            f"No rear plate detected for camera pair {front_camera_id}/{rear_camera_id}"
-        )
-        _send_alert(
-            alert_type="no_rear_plate",
-            visit_id=visit_id,
-            plate=front_plate,
-            camera_id=rear_camera_id,
-            message=f"No rear plate detected for front plate {front_plate}",
-            event_data=rear_event,
-        )
-
-        if not front_plate:
-            return None
+    if _check_no_rear_plate_alert(
+        rear_camera_id, rear_plate, rear_event, front_plate, visit_id
+    ):
+        return None
 
     # Alert #1: Plate Mismatch Alert (either camera plate not in Front-Rear DB)
-    front_in_db, front_vehicle_info = _check_plate_in_vehicles_db(front_plate)
-    rear_in_db, rear_vehicle_info = _check_plate_in_vehicles_db(rear_plate)
-
-    if front_plate and not front_in_db:
-        logging.warning(f"Front plate {front_plate} not found in Front-Rear database")
-        if front_camera_id:
-            _send_alert(
-                alert_type="plate_mismatch",
-                visit_id=visit_id,
-                plate=front_plate,
-                camera_id=front_camera_id,
-                message=f"License plate {front_plate} not found in Front-Rear Vehicle Database",
-                event_data=front_event,
-                detected_make_model=detected_make_model,
-                make_model_score=make_model_score,
-            )
-
-    if rear_plate and not rear_in_db:
-        logging.warning(f"Rear plate {rear_plate} not found in Front-Rear database")
-        if rear_camera_id:
-            _send_alert(
-                alert_type="plate_mismatch",
-                visit_id=visit_id,
-                plate=rear_plate,
-                camera_id=rear_camera_id,
-                message=f"License plate {rear_plate} not found in Front-Rear Vehicle Database",
-                event_data=rear_event,
-                detected_make_model=detected_make_model,
-                make_model_score=make_model_score,
-            )
+    front_in_db, rear_in_db, front_vehicle_info, rear_vehicle_info = (
+        _check_plate_mismatch_alerts(
+            front_plate,
+            rear_plate,
+            front_camera_id,
+            rear_camera_id,
+            front_event,
+            rear_event,
+            detected_make_model,
+            make_model_score,
+            visit_id,
+        )
+    )
 
     # Alert #3: Make/Model Mismatch Alert
-    # Reload config for hot reload support
-    current_config = _load_config()
-    make_model_threshold = current_config.get("thresholds", {}).get(
-        "make_model_confidence", 0.2
+    _check_make_model_mismatch_alert(
+        rear_camera_id,
+        front_camera_id,
+        rear_plate,
+        front_plate,
+        rear_in_db,
+        front_in_db,
+        rear_vehicle_info,
+        front_vehicle_info,
+        detected_make_model,
+        make_model_score,
+        rear_event,
+        front_event,
+        visit_id,
     )
-    reference_plate = (
-        rear_plate if rear_in_db else (front_plate if front_in_db else None)
-    )
-    reference_vehicle_info = rear_vehicle_info if rear_in_db else front_vehicle_info
-
-    if reference_plate and reference_vehicle_info:
-        front_rear_make = reference_vehicle_info.get("make", "")
-        front_rear_model = reference_vehicle_info.get("model", "")
-        front_rear_make_model = f"{front_rear_make} {front_rear_model}".strip()
-        make_model_mismatch = (
-            detected_make_model and detected_make_model != front_rear_make_model
-        )
-
-        if make_model_mismatch and make_model_score >= make_model_threshold:
-            logging.warning(
-                f"Make/model mismatch for {reference_plate}: "
-                f"Detected: {detected_make_model} (score: {make_model_score:.2f}), "
-                f"Front-Rear DB: {front_rear_make_model}"
-            )
-            alert_camera_id = (
-                rear_camera_id
-                if (rear_camera_id and rear_plate)
-                else (front_camera_id if front_camera_id else None)
-            )
-            if alert_camera_id:
-                _send_alert(
-                    alert_type="make_model_mismatch",
-                    visit_id=visit_id,
-                    plate=reference_plate,
-                    camera_id=alert_camera_id,
-                    message=(
-                        f"Vehicle make/model mismatch for {reference_plate}: "
-                        f"Detected {detected_make_model} (confidence: {make_model_score:.2f}), "
-                        f"Expected {front_rear_make_model} from Front-Rear database"
-                    ),
-                    event_data=rear_event if rear_event else front_event,
-                    detected_make_model=detected_make_model,
-                    make_model_score=make_model_score,
-                )
 
     return visit_id
 
@@ -850,8 +934,8 @@ def _handle_event_overwrite(
     if old_plate != new_plate:
         if not pair.is_solo:
             logging.warning(
-                f"Overwriting unpaired event from {camera_id} (age: {age:.1f}s, old plate: {old_plate}) - "
-                f"new vehicle ({new_plate}) detected before pair completed, {missing_camera} may be offline"
+                f"Overwriting unpaired event from {_short(camera_id)} (age: {age:.1f}s, old plate: {old_plate}) - "
+                f"new vehicle ({new_plate}) detected before pair completed, {_short(missing_camera)} may be offline"
             )
 
         old_front_event = old_event if is_front else None
@@ -907,7 +991,7 @@ def process_request(
     pair = _get_camera_pair(camera_id)
 
     if not pair:
-        logging.warning(f"Camera {camera_id} is not configured in any pair")
+        logging.warning(f"Camera {_short(camera_id)} is not configured in any pair")
         return "Camera not configured in any pair", 200
 
     timestamp_unix = _parse_timestamp(timestamp_str)
@@ -942,11 +1026,9 @@ def process_request(
         else:
             pair.rear_event = event
 
-    if (
-        should_send_overwrite_alert
-        and missing_camera_id is not None
-        and not pair.is_solo
-    ):
+    if should_send_overwrite_alert and not pair.is_solo:
+        assert missing_camera_id is not None
+
         visit_id = _process_events(
             front_event=old_front_event,
             rear_event=old_rear_event,
@@ -961,7 +1043,7 @@ def process_request(
                 visit_id=visit_id,
                 plate=None,
                 camera_id=missing_camera_id,
-                message=f"Camera {missing_camera_id} may be offline - unpaired event overwritten after {overwrite_age:.1f}s",
+                message=f"Camera {_short(missing_camera_id)} may be offline - unpaired event overwritten after {overwrite_age:.1f}s",
                 event_data=overwrite_old_event,
             )
 
@@ -975,9 +1057,11 @@ def process_request(
 
         if should_process_pair:
             if pair.is_solo:
-                logging.info(f"Processing solo camera {pair.solo_camera_id}")
+                logging.info(f"Processing solo camera {_short(pair.solo_camera_id)}")
             else:
-                logging.info(f"Processing camera pair {pair.front}/{pair.rear}")
+                logging.info(
+                    f"Processing camera pair {_short(pair.front)}/{_short(pair.rear)}"
+                )
 
             _process_camera_pair(pair)
             pair.front_event = None
@@ -991,15 +1075,15 @@ def process_request(
 
         if not front_valid:
             status_msg.append(
-                f"front camera ({pair.front}) {'missing' if not front_event else 'expired'}"
+                f"front camera ({_short(pair.front)}) {'missing' if not front_event else 'expired'}"
             )
         if not rear_valid:
             status_msg.append(
-                f"rear camera ({pair.rear}) {'missing' if not rear_event else 'expired'}"
+                f"rear camera ({_short(pair.rear)}) {'missing' if not rear_event else 'expired'}"
             )
 
         logging.info(
-            f"Event buffered for {camera_id}, waiting for: {', '.join(status_msg)}"
+            f"Event buffered for {pair.description} ({_short(camera_id)}), waiting for: {', '.join(status_msg)}"
         )
 
-    return "Event buffered, waiting for pair", 200
+    return "Event buffered, waiting for pair", 202

--- a/webhooks/middleware/protocols/front_rear.py
+++ b/webhooks/middleware/protocols/front_rear.py
@@ -49,7 +49,7 @@ class ParkPowError(Exception):
         self.message = message
 
 
-@dataclass
+@dataclass(slots=True)
 class CameraEvent:
     """Structured webhook event from a camera."""
 
@@ -62,7 +62,7 @@ class CameraEvent:
     original_files: Any
 
 
-@dataclass
+@dataclass(slots=True)
 class AlertCheckContext:
     """Shared payload used by alert-check helper functions."""
 
@@ -77,7 +77,7 @@ class AlertCheckContext:
     visit_id: int
 
 
-@dataclass
+@dataclass(slots=True)
 class CameraPair:
     """Paired front/rear camera configuration with event buffering."""
 

--- a/webhooks/middleware/protocols/front_rear.py
+++ b/webhooks/middleware/protocols/front_rear.py
@@ -27,12 +27,12 @@ import threading
 import time
 from collections import defaultdict
 from dataclasses import dataclass
-from datetime import datetime
 from threading import Lock
 from typing import Any
 
 import aiohttp
 
+from protocols import front_rear_helpers as h
 from protocols.shared.utils import get_header
 
 logging.basicConfig(
@@ -345,13 +345,6 @@ def _cleanup_task_loop() -> None:
         time.sleep(cleanup_interval)
 
 
-def _short(camera_id: str | None) -> str:
-    """Helper to shorten camera ID for logging."""
-    if not camera_id:
-        return ""
-    return f"...{camera_id[-12:]}" if len(camera_id) >= 60 else camera_id
-
-
 def _cleanup_expired_events() -> None:
     """Remove expired events from buffer to prevent memory bloat."""
     global config
@@ -391,7 +384,7 @@ def _cleanup_expired_events() -> None:
             missing_camera = pair.rear if is_front else pair.front
 
         logging.warning(
-            f"Unpaired event for {pair.description} ({_short(camera_id)}) expired after {age:.1f}s, {missing_camera} may be offline, processing single camera event"
+            f"Unpaired event for {pair.description} ({h.shorten_id(camera_id)}) expired after {age:.1f}s, {missing_camera} may be offline, processing single camera event"
         )
 
         try:
@@ -435,48 +428,6 @@ def _get_camera_pair(camera_id: str) -> CameraPair | None:
         ),
         None,
     )
-
-
-def _extract_plate(result: dict[str, Any]) -> str | None:
-    """Extract license plate from result. Stream sends plate as a simple string."""
-    plate = result.get("plate")
-
-    if not plate or not isinstance(plate, str):
-        logging.error(f"Invalid plate data: {plate} (type: {type(plate).__name__})")
-        return None
-
-    return plate.strip().upper()
-
-
-def _extract_best_make_model(results: list[dict[str, Any]]) -> tuple[str | None, float]:
-    """Extract highest confidence make/model as "MAKE MODEL" string and score."""
-    best_make_model = None
-    best_score = 0.0
-
-    for result in results:
-        model_make_list = result.get("model_make", [])
-
-        for mm in model_make_list:
-            make = mm.get("make", "").strip().upper()
-            model = mm.get("model", "").strip().upper()
-            score = mm.get("score", 0.0)
-
-            if (make or model) and score > best_score:
-                best_make_model = f"{make} {model}".strip()
-                best_score = score
-
-    return best_make_model, best_score
-
-
-def _check_plate_in_vehicles_db(
-    plate: str | None,
-) -> tuple[bool, dict[str, str] | None]:
-    """Check if plate exists in database. Returns (found, vehicle_info)."""
-    if not plate:
-        return False, None
-
-    vehicle_info = csv_vehicles.get(plate.upper())
-    return vehicle_info is not None, vehicle_info
 
 
 async def _send_alert_async(
@@ -697,8 +648,12 @@ def _check_plate_mismatch_alerts(
     visit_id: int,
 ) -> tuple[bool, bool, dict[str, str] | None, dict[str, str] | None]:
     """Check and send plate mismatch alerts. Returns (front_in_db, rear_in_db, front_info, rear_info)."""
-    front_in_db, front_vehicle_info = _check_plate_in_vehicles_db(front_plate)
-    rear_in_db, rear_vehicle_info = _check_plate_in_vehicles_db(rear_plate)
+    front_in_db, front_vehicle_info = h.check_plate_in_vehicles_db(
+        front_plate, csv_vehicles
+    )
+    rear_in_db, rear_vehicle_info = h.check_plate_in_vehicles_db(
+        rear_plate, csv_vehicles
+    )
 
     if front_plate and not front_in_db:
         logging.warning(f"Front plate {front_plate} not found in Front-Rear database")
@@ -809,10 +764,10 @@ def _process_events(
     rear_plate = None
 
     if front_event and front_event.results:
-        front_plate = _extract_plate(front_event.results[0])
+        front_plate = h.extract_plate(front_event.results[0])
 
     if rear_event and rear_event.results:
-        rear_plate = _extract_plate(rear_event.results[0])
+        rear_plate = h.extract_plate(rear_event.results[0])
 
     all_results = []
     if front_event and front_event.results:
@@ -821,13 +776,13 @@ def _process_events(
         all_results.extend(rear_event.results)
 
     detected_make_model, make_model_score = (
-        _extract_best_make_model(all_results) if all_results else (None, 0.0)
+        h.extract_best_make_model(all_results) if all_results else (None, 0.0)
     )
 
     data_to_forward = rear_event if rear_event else front_event
     if not data_to_forward:
         is_solo = not (front_camera_id and rear_camera_id)
-        camera_pair = f"{_short(front_camera_id)}{'' if is_solo else ' / '}{_short(rear_camera_id)}"
+        camera_pair = f"{h.shorten_id(front_camera_id)}{'' if is_solo else ' / '}{h.shorten_id(rear_camera_id)}"
         logging.warning(
             f"No event data to forward for {'camera' if is_solo else 'pair'} {camera_pair}"
         )
@@ -836,7 +791,7 @@ def _process_events(
     visit_id = _forward_to_parkpow(data_to_forward)
     if not visit_id:
         is_solo = not front_camera_id or not rear_camera_id
-        camera_pair = f"{_short(front_camera_id)}{'' if is_solo else ' / '}{_short(rear_camera_id)}"
+        camera_pair = f"{h.shorten_id(front_camera_id)}{'' if is_solo else ' / '}{h.shorten_id(rear_camera_id)}"
         logging.error(
             f"Failed to create visit in ParkPow for {'camera' if is_solo else 'pair'} {camera_pair}, skipping alerts"
         )
@@ -893,21 +848,6 @@ def _process_camera_pair(pair: CameraPair) -> int | None:
     )
 
 
-def _stream_response(
-    message: str, status: int, camera_id: str | None = None
-) -> tuple[str, int]:
-    """Log exactly what is returned to Stream and return it."""
-    cam = f" for {_short(camera_id)}" if camera_id else ""
-    log = f"Returned {status} {message!r}{cam}"
-    if status >= 500:
-        logging.error(log)
-    elif status >= 400:
-        logging.warning(log)
-    else:
-        logging.info(log)
-    return message, status
-
-
 def _authenticate_request(json_data: dict[str, Any]) -> tuple[str, int] | None:
     """Authenticate webhook request. Returns None if valid, or (error_msg, status) tuple."""
     auth_header = get_header("Authorization", json_data)
@@ -923,22 +863,6 @@ def _authenticate_request(json_data: dict[str, Any]) -> tuple[str, int] | None:
         return "FrontRear - Forbidden: Invalid token", 403
 
     return None
-
-
-def _parse_timestamp(timestamp_str: str) -> float:
-    """Parse timestamp string to unix timestamp. Returns current time if parsing fails."""
-    try:
-        if "T" in timestamp_str and timestamp_str.endswith("Z"):
-            timestamp_str = timestamp_str.replace("Z", "+00:00")
-            dt = datetime.fromisoformat(timestamp_str)
-        else:
-            dt = datetime.strptime(timestamp_str, "%Y-%m-%d %H:%M:%S.%f")
-        return dt.timestamp()
-    except (ValueError, AttributeError) as e:
-        logging.warning(
-            f"Failed to parse timestamp '{timestamp_str}': {e}, using current time"
-        )
-        return time.time()
 
 
 def _handle_event_overwrite(
@@ -966,13 +890,13 @@ def _handle_event_overwrite(
     age = time.time() - old_timestamp
     missing_camera = pair.rear if is_front else pair.front
 
-    old_plate = _extract_plate(old_event.results[0]) if old_event.results else None
-    new_plate = _extract_plate(new_results[0]) if new_results else None
+    old_plate = h.extract_plate(old_event.results[0]) if old_event.results else None
+    new_plate = h.extract_plate(new_results[0]) if new_results else None
 
     if old_plate != new_plate:
         if not pair.is_solo:
             logging.warning(
-                f"Overwriting unpaired event from {_short(camera_id)} (age: {age:.1f}s, old plate: {old_plate}) - "
+                f"Overwriting unpaired event from {h.shorten_id(camera_id)} (age: {age:.1f}s, old plate: {old_plate}) - "
                 f"new vehicle ({new_plate}) detected before pair completed, {missing_camera} may be offline"
             )
 
@@ -1020,7 +944,7 @@ def process_request(
     """Process incoming webhook request from camera."""
     auth_error = _authenticate_request(json_data)
     if auth_error:
-        return _stream_response(*auth_error)
+        return h.stream_response(*auth_error)
 
     data = json_data.get("data", {})
     camera_id = data.get("camera_id")
@@ -1029,11 +953,11 @@ def process_request(
     pair = _get_camera_pair(camera_id)
 
     if not pair:
-        return _stream_response(
+        return h.stream_response(
             "FrontRear - Camera not configured in any pair", 404, camera_id
         )
 
-    timestamp_unix = _parse_timestamp(timestamp_str)
+    timestamp_unix = h.parse_timestamp(timestamp_str)
 
     event = CameraEvent(
         camera_id=camera_id,
@@ -1100,10 +1024,12 @@ def process_request(
 
         if should_process_pair:
             if pair.is_solo:
-                logging.info(f"Processing solo camera {_short(pair.solo_camera_id)}")
+                logging.info(
+                    f"Processing solo camera {h.shorten_id(pair.solo_camera_id)}"
+                )
             else:
                 logging.info(
-                    f"Processing camera pair {_short(pair.front)} / {_short(pair.rear)}"
+                    f"Processing camera pair {h.shorten_id(pair.front)} / {h.shorten_id(pair.rear)}"
                 )
 
             try:
@@ -1111,17 +1037,19 @@ def process_request(
             except ParkPowError as e:
                 pair.front_event = None
                 pair.rear_event = None
-                return _stream_response(f"ParkPow - {e.message}", e.status, camera_id)
+                return h.stream_response(f"ParkPow - {e.message}", e.status, camera_id)
 
             pair.front_event = None
             pair.rear_event = None
 
             if visit_id is None:
-                return _stream_response(
+                return h.stream_response(
                     "FrontRear - Internal error (null visit_id)", 424, camera_id
                 )
 
-            return _stream_response("FrontRear - Processed camera pair", 200, camera_id)
+            return h.stream_response(
+                "FrontRear - Processed camera pair", 200, camera_id
+            )
 
     if not pair.is_solo:
         front_event = pair.front_event
@@ -1130,17 +1058,17 @@ def process_request(
 
         if not front_valid:
             status_msg.append(
-                f"front camera ({_short(pair.front)}) {'missing' if not front_event else 'expired'}"
+                f"front camera ({h.shorten_id(pair.front)}) {'missing' if not front_event else 'expired'}"
             )
         if not rear_valid:
             status_msg.append(
-                f"rear camera ({_short(pair.rear)}) {'missing' if not rear_event else 'expired'}"
+                f"rear camera ({h.shorten_id(pair.rear)}) {'missing' if not rear_event else 'expired'}"
             )
 
         logging.info(
-            f"Event buffered for {pair.description} ({_short(camera_id)}), waiting for: {', '.join(status_msg)}"
+            f"Event buffered for {pair.description} ({h.shorten_id(camera_id)}), waiting for: {', '.join(status_msg)}"
         )
 
-    return _stream_response(
+    return h.stream_response(
         "FrontRear - Event buffered, waiting for pair", 202, camera_id
     )

--- a/webhooks/middleware/protocols/front_rear.py
+++ b/webhooks/middleware/protocols/front_rear.py
@@ -1063,8 +1063,6 @@ def process_request(
             pair.rear_event = event
 
     if should_send_overwrite_alert and not pair.is_solo:
-        assert missing_camera_id is not None
-
         try:
             visit_id = _process_events(
                 front_event=old_front_event,

--- a/webhooks/middleware/protocols/front_rear.py
+++ b/webhooks/middleware/protocols/front_rear.py
@@ -331,7 +331,7 @@ def _cleanup_task_loop() -> None:
 
 def _short(camera_id: str | None) -> str | None:
     """Helper to shorten camera ID for logging."""
-    return f"...{camera_id[-9:]}" if camera_id else None
+    return f"...{camera_id[-12:]}" if camera_id and len(camera_id) >= 60 else camera_id
 
 
 def _cleanup_expired_events() -> None:
@@ -998,7 +998,7 @@ def process_request(
     pair = _get_camera_pair(camera_id)
 
     if not pair:
-        logging.warning(f"Camera {_short(camera_id)} is not configured in any pair")
+        logging.warning(f"Camera {camera_id} is not configured in any pair")
         return "Camera not configured in any pair", 200
 
     timestamp_unix = _parse_timestamp(timestamp_str)

--- a/webhooks/middleware/protocols/front_rear.py
+++ b/webhooks/middleware/protocols/front_rear.py
@@ -331,7 +331,9 @@ def _cleanup_task_loop() -> None:
 
 def _short(camera_id: str | None) -> str:
     """Helper to shorten camera ID for logging."""
-    return f"...{camera_id[-12:]}" if camera_id else ""
+    if not camera_id:
+        return ""
+    return f"...{camera_id[-12:]}" if len(camera_id) >= 60 else camera_id
 
 
 def _cleanup_expired_events() -> None:

--- a/webhooks/middleware/protocols/front_rear.py
+++ b/webhooks/middleware/protocols/front_rear.py
@@ -95,14 +95,12 @@ class CameraPair:
 
     @property
     def is_solo(self) -> bool:
-        """Check if this is a solo camera (only front or only rear)."""
         return (self.front is None or self.front == "") or (
             self.rear is None or self.rear == ""
         )
 
     @property
     def solo_camera_id(self) -> str | None:
-        """Get the camera ID for solo camera (front or rear)."""
         if not self.is_solo:
             return None
         return self.front or self.rear
@@ -387,8 +385,7 @@ def _cleanup_expired_events() -> None:
                 expired_items.append((pair, pair.rear, pair.rear_event))
 
     for pair, camera_id, event in expired_items:
-        pair_id = pair.id
-        with pair_locks[pair_id]:
+        with pair_locks[pair.id]:
             is_front = camera_id == pair.front
             current_event = pair.front_event if is_front else pair.rear_event
 
@@ -410,7 +407,7 @@ def _cleanup_expired_events() -> None:
             )
             visit_id = None
 
-        with pair_locks[pair_id]:
+        with pair_locks[pair.id]:
             is_front = camera_id == pair.front
             if is_front:
                 pair.front_event = None
@@ -438,8 +435,7 @@ def _get_camera_pair(camera_id: str) -> CameraPair | None:
         (
             pair
             for pair in camera_pairs
-            if (pair.front and pair.front == camera_id)
-            or (pair.rear and pair.rear == camera_id)
+            if pair.front == camera_id or pair.rear == camera_id
         ),
         None,
     )
@@ -704,8 +700,12 @@ def _check_make_model_mismatch_alert(
     front_rear_make = reference_vehicle_info.get("make", "")
     front_rear_model = reference_vehicle_info.get("model", "")
     front_rear_make_model = f"{front_rear_make} {front_rear_model}".strip()
+    normalized_expected = front_rear_make_model.upper()
+    normalized_detected = (
+        ctx.detected_make_model.strip().upper() if ctx.detected_make_model else None
+    )
     make_model_mismatch = (
-        ctx.detected_make_model and ctx.detected_make_model != front_rear_make_model
+        normalized_detected is not None and normalized_detected != normalized_expected
     )
 
     if not (make_model_mismatch and ctx.make_model_score >= make_model_threshold):
@@ -772,21 +772,21 @@ def _process_events(
         visit_id=0,
     )
 
-    data_to_forward = rear_event if rear_event else front_event
+    data_to_forward = rear_event or front_event
     if not data_to_forward:
-        is_solo = not (front_camera_id and rear_camera_id)
-        camera_pair = f"{h.shorten_id(front_camera_id)}{'' if is_solo else ' / '}{h.shorten_id(rear_camera_id)}"
-        logging.warning(
-            f"No event data to forward for {'camera' if is_solo else 'pair'} {camera_pair}"
+        target_kind, target_label = h.format_camera_target(
+            front_camera_id, rear_camera_id
         )
+        logging.warning(f"No event data to forward for {target_kind} {target_label}")
         return None
 
     visit_id = _forward_to_parkpow(data_to_forward)
     if not visit_id:
-        is_solo = not front_camera_id or not rear_camera_id
-        camera_pair = f"{h.shorten_id(front_camera_id)}{'' if is_solo else ' / '}{h.shorten_id(rear_camera_id)}"
+        target_kind, target_label = h.format_camera_target(
+            front_camera_id, rear_camera_id
+        )
         logging.error(
-            f"Failed to create visit in ParkPow for {'camera' if is_solo else 'pair'} {camera_pair}, skipping alerts"
+            f"Failed to create visit in ParkPow for {target_kind} {target_label}, skipping alerts"
         )
         return None
     alert_ctx.visit_id = visit_id
@@ -800,16 +800,10 @@ def _process_events(
         _check_plate_mismatch_alerts(alert_ctx)
     )
 
-    reference_plate = (
-        rear_plate if rear_in_db else (front_plate if front_in_db else None)
-    )
+    reference_plate = rear_plate if rear_in_db else front_plate if front_in_db else None
     reference_vehicle_info = rear_vehicle_info if rear_in_db else front_vehicle_info
-    alert_camera_id = (
-        rear_camera_id
-        if (rear_camera_id and rear_plate)
-        else (front_camera_id if front_camera_id else None)
-    )
-    event_data = rear_event if rear_event else front_event
+    alert_camera_id = rear_camera_id if rear_plate else front_camera_id
+    event_data = rear_event or front_event
     current_config = _load_config()
     make_model_threshold = current_config.get("thresholds", {}).get(
         "make_model_confidence", 0.2
@@ -907,12 +901,7 @@ def _check_pairing_readiness(
     Returns: (should_process, front_valid, rear_valid)
     """
     if pair.is_solo:
-        front_event = pair.front_event
-        rear_event = pair.rear_event
-        should_process = bool(
-            (pair.front and front_event) or (pair.rear and rear_event)
-        )
-        return should_process, False, False
+        return bool(pair.front_event or pair.rear_event), False, False
 
     now = time.time()
     front_event = pair.front_event
@@ -958,10 +947,9 @@ def process_request(
         original_files=all_files,
     )
 
-    pair_id = pair.id
     is_front = camera_id == pair.front
 
-    with pair_locks[pair_id]:
+    with pair_locks[pair.id]:
         old_event = pair.front_event if is_front else pair.rear_event
 
         (
@@ -1006,7 +994,7 @@ def process_request(
     current_config = _load_config()
     time_window = current_config.get("pairing", {}).get("time_window_seconds", 30)
 
-    with pair_locks[pair_id]:
+    with pair_locks[pair.id]:
         should_process_pair, front_valid, rear_valid = _check_pairing_readiness(
             pair, time_window
         )

--- a/webhooks/middleware/protocols/front_rear.py
+++ b/webhooks/middleware/protocols/front_rear.py
@@ -846,7 +846,7 @@ def _process_events(
     if _check_no_rear_plate_alert(
         rear_camera_id, rear_plate, rear_event, front_plate, visit_id
     ):
-        return None
+        return visit_id
 
     # Alert #1: Plate Mismatch Alert (either camera plate not in Front-Rear DB)
     front_in_db, rear_in_db, front_vehicle_info, rear_vehicle_info = (

--- a/webhooks/middleware/protocols/front_rear.py
+++ b/webhooks/middleware/protocols/front_rear.py
@@ -39,6 +39,15 @@ logging.basicConfig(
 )
 
 
+class ParkPowError(Exception):
+    """Raised when ParkPow returns an HTTP error or is unreachable."""
+
+    def __init__(self, status: int, message: str) -> None:
+        super().__init__(message)
+        self.status = status
+        self.message = message
+
+
 @dataclass
 class CameraEvent:
     """Structured webhook event from a camera."""
@@ -378,7 +387,13 @@ def _cleanup_expired_events() -> None:
             f"Unpaired event for {pair.description} ({_short(camera_id)}) expired after {age:.1f}s, {missing_camera} may be offline, processing single camera event"
         )
 
-        visit_id = _process_camera_pair(pair)
+        try:
+            visit_id = _process_camera_pair(pair)
+        except ParkPowError as e:
+            logging.error(
+                f"ParkPow error processing expired event for {pair.description}: [{e.status}] {e.message}"
+            )
+            visit_id = None
 
         with pair_locks[pair_id]:
             is_front = camera_id == pair.front
@@ -601,13 +616,23 @@ async def _forward_to_parkpow_async(event: CameraEvent) -> int | None:
             logging.info(f"Created visit {visit_id} in ParkPow")
             return int(visit_id)
         elif "requires higher scores" in str(response_data).lower():
-            return -1
+            raise ParkPowError(422, "Visit rejected due to low confidence scores")
         else:
             logging.warning(
                 f"ParkPow response missing or invalid visit id: {response_data}"
             )
             return None
 
+    except ParkPowError:
+        raise
+    except aiohttp.ClientResponseError as e:
+        raise ParkPowError(e.status, e.message) from e
+    except (
+        aiohttp.ServerTimeoutError,
+        aiohttp.ClientConnectorError,
+        asyncio.TimeoutError,
+    ) as e:
+        raise ParkPowError(503, str(e)) from e
     except Exception as e:
         logging.error(f"Failed to forward to ParkPow: {e}")
         return None
@@ -622,6 +647,8 @@ def _forward_to_parkpow(event: CameraEvent) -> int | None:
     future = asyncio.run_coroutine_threadsafe(_forward_to_parkpow_async(event), _loop)
     try:
         return future.result(timeout=15)
+    except ParkPowError:
+        raise
     except Exception as e:
         logging.error(f"Failed to forward to ParkPow: {e}")
         return None
@@ -798,19 +825,6 @@ def _process_events(
         return None
 
     visit_id = _forward_to_parkpow(data_to_forward)
-    if visit_id == -1:
-        is_solo = not front_camera_id or not rear_camera_id
-        camera_pair = f"{_short(front_camera_id)}{' / ' if not is_solo else ''}{_short(rear_camera_id)}"
-        plates = (
-            f"front={front_plate}, rear={rear_plate}"
-            if not is_solo
-            else f"plate={front_plate or rear_plate}"
-        )
-        logging.warning(
-            f"ParkPow rejected visit for {'camera' if is_solo else 'pair'} {camera_pair} ({plates}) - confidence scores too low"
-        )
-        return -1
-
     if not visit_id:
         is_solo = not front_camera_id or not rear_camera_id
         camera_pair = f"{_short(front_camera_id)}{' / ' if not is_solo else ''}{_short(rear_camera_id)}"
@@ -870,28 +884,37 @@ def _process_camera_pair(pair: CameraPair) -> int | None:
     )
 
 
+def _stream_response(
+    message: str, status: int, camera_id: str | None = None
+) -> tuple[str, int]:
+    """Log exactly what is returned to Stream and return it."""
+    cam = f" for {_short(camera_id)}" if camera_id else ""
+    log = f"Returned {status} {message!r}{cam}"
+    if status >= 500:
+        logging.error(log)
+    elif status >= 400:
+        logging.warning(log)
+    else:
+        logging.info(log)
+    return message, status
+
+
 def _authenticate_request(json_data: dict[str, Any]) -> tuple[str, int] | None:
     """Authenticate webhook request. Returns None if valid, or (error_msg, status) tuple."""
     if not _stream_api_tokens:
-        logging.error(
-            "STREAM_API_TOKENS not configured - rejecting request for security"
-        )
-        return "Unauthorized: Authentication not configured", 401
+        return "FrontRear - Unauthorized: Authentication not configured", 401
 
     auth_header = get_header("Authorization", json_data)
     if not auth_header:
-        logging.error("Missing Authorization header in request from Stream")
-        return "Unauthorized: Missing Authorization header", 401
+        return "FrontRear - Unauthorized: Missing Authorization header", 401
 
     token = auth_header.split()[-1]
 
     if not token or token.lower() in ("token", "bearer"):
-        logging.error("Invalid or missing token in Authorization header")
-        return "Unauthorized: Malformed Authorization header", 401
+        return "FrontRear - Unauthorized: Malformed Authorization header", 401
 
     if not any(hmac.compare_digest(token, v_token) for v_token in _stream_api_tokens):
-        logging.error("Invalid token in Authorization header")
-        return "Forbidden: Invalid token", 403
+        return "FrontRear - Unauthorized: Invalid token", 403
 
     return None
 
@@ -991,7 +1014,7 @@ def process_request(
     """Process incoming webhook request from camera."""
     auth_error = _authenticate_request(json_data)
     if auth_error:
-        return auth_error
+        return _stream_response(*auth_error)
 
     data = json_data.get("data", {})
     camera_id = data.get("camera_id")
@@ -1000,8 +1023,9 @@ def process_request(
     pair = _get_camera_pair(camera_id)
 
     if not pair:
-        logging.warning(f"Camera {camera_id} is not configured in any pair")
-        return "Camera not configured in any pair", 200
+        return _stream_response(
+            "FrontRear - Camera not configured in any pair", 404, camera_id
+        )
 
     timestamp_unix = _parse_timestamp(timestamp_str)
 
@@ -1038,12 +1062,18 @@ def process_request(
     if should_send_overwrite_alert and not pair.is_solo:
         assert missing_camera_id is not None
 
-        visit_id = _process_events(
-            front_event=old_front_event,
-            rear_event=old_rear_event,
-            front_camera_id=pair.front,
-            rear_camera_id=pair.rear,
-        )
+        try:
+            visit_id = _process_events(
+                front_event=old_front_event,
+                rear_event=old_rear_event,
+                front_camera_id=pair.front,
+                rear_camera_id=pair.rear,
+            )
+        except ParkPowError as e:
+            logging.error(
+                f"ParkPow error processing overwrite event for {pair.description}: [{e.status}] {e.message}"
+            )
+            visit_id = None
 
         # Alert #4: Possible Offline Camera Alert
         if visit_id:
@@ -1072,14 +1102,20 @@ def process_request(
                     f"Processing camera pair {_short(pair.front)}/{_short(pair.rear)}"
                 )
 
-            visit_id = _process_camera_pair(pair)
+            try:
+                visit_id = _process_camera_pair(pair)
+            except ParkPowError as e:
+                pair.front_event = None
+                pair.rear_event = None
+                return _stream_response(f"ParkPow - {e.message}", e.status, camera_id)
+
             pair.front_event = None
             pair.rear_event = None
 
-            if visit_id == -1:
-                return "Visit rejected: confidence scores too low", 422
+            if visit_id is None:
+                return _stream_response("FrontRear - Internal error", 424, camera_id)
 
-            return "Processed camera pair", 200
+            return _stream_response("FrontRear - Processed camera pair", 200, camera_id)
 
     if not pair.is_solo:
         front_event = pair.front_event
@@ -1099,4 +1135,6 @@ def process_request(
             f"Event buffered for {pair.description} ({_short(camera_id)}), waiting for: {', '.join(status_msg)}"
         )
 
-    return "Event buffered, waiting for pair", 202
+    return _stream_response(
+        "FrontRear - Event buffered, waiting for pair", 202, camera_id
+    )

--- a/webhooks/middleware/protocols/front_rear.py
+++ b/webhooks/middleware/protocols/front_rear.py
@@ -356,6 +356,8 @@ def _cleanup_expired_events() -> None:
     expired_items: list[tuple[CameraPair, str, CameraEvent]] = []
 
     for pair in camera_pairs:
+        if pair.is_solo:
+            continue
         with pair_locks[pair.id]:
             if (
                 pair.front
@@ -381,8 +383,6 @@ def _cleanup_expired_events() -> None:
 
             age = time.time() - current_event.timestamp_unix
             missing_camera = pair.rear if is_front else pair.front
-
-        assert missing_camera is not None
 
         logging.warning(
             f"Unpaired event for {pair.description} ({_short(camera_id)}) expired after {age:.1f}s, {missing_camera} may be offline, processing single camera event"

--- a/webhooks/middleware/protocols/front_rear_helpers.py
+++ b/webhooks/middleware/protocols/front_rear_helpers.py
@@ -82,3 +82,15 @@ def check_plate_in_vehicles_db(
 
     vehicle_info = csv_db.get(plate.upper())
     return vehicle_info is not None, vehicle_info
+
+
+def format_camera_target(
+    front_camera_id: str | None, rear_camera_id: str | None
+) -> tuple[str, str]:
+    """Format camera target label for logs."""
+    is_solo = not front_camera_id or not rear_camera_id
+    camera_target = (
+        f"{shorten_id(front_camera_id)}"
+        f"{'' if is_solo else ' / '}{shorten_id(rear_camera_id)}"
+    )
+    return ("camera" if is_solo else "pair"), camera_target

--- a/webhooks/middleware/protocols/front_rear_helpers.py
+++ b/webhooks/middleware/protocols/front_rear_helpers.py
@@ -1,0 +1,84 @@
+import logging
+import time
+from datetime import datetime
+from typing import Any
+
+
+def parse_timestamp(timestamp_str: str) -> float:
+    """Parse timestamp string to unix timestamp. Returns current time if parsing fails."""
+    try:
+        if "T" in timestamp_str and timestamp_str.endswith("Z"):
+            timestamp_str = timestamp_str.replace("Z", "+00:00")
+            dt = datetime.fromisoformat(timestamp_str)
+        else:
+            dt = datetime.strptime(timestamp_str, "%Y-%m-%d %H:%M:%S.%f")
+        return dt.timestamp()
+    except (ValueError, AttributeError) as e:
+        logging.warning(
+            f"Failed to parse timestamp '{timestamp_str}': {e}, using current time"
+        )
+        return time.time()
+
+
+def shorten_id(camera_id: str | None) -> str:
+    """Helper to shorten camera ID for logging."""
+    if not camera_id:
+        return ""
+    return f"...{camera_id[-12:]}" if len(camera_id) >= 60 else camera_id
+
+
+def extract_plate(result: dict[str, Any]) -> str | None:
+    """Extract license plate from result. Stream sends plate as a simple string."""
+    plate = result.get("plate")
+
+    if not plate or not isinstance(plate, str):
+        logging.error(f"Invalid plate data: {plate} (type: {type(plate).__name__})")
+        return None
+
+    return plate.strip().upper()
+
+
+def extract_best_make_model(results: list[dict[str, Any]]) -> tuple[str | None, float]:
+    """Extract highest confidence make/model as "MAKE MODEL" string and score."""
+    best_make_model = None
+    best_score = 0.0
+
+    for result in results:
+        model_make_list = result.get("model_make", [])
+
+        for mm in model_make_list:
+            make = mm.get("make", "").strip().upper()
+            model = mm.get("model", "").strip().upper()
+            score = mm.get("score", 0.0)
+
+            if (make or model) and score > best_score:
+                best_make_model = f"{make} {model}".strip()
+                best_score = score
+
+    return best_make_model, best_score
+
+
+def stream_response(
+    message: str, status: int, camera_id: str | None = None
+) -> tuple[str, int]:
+    """Log exactly what is returned to Stream and return it."""
+    cam = f" for {shorten_id(camera_id)}" if camera_id else ""
+    log = f"Returned {status} {message!r}{cam}"
+    if status >= 500:
+        logging.error(log)
+    elif status >= 400:
+        logging.warning(log)
+    else:
+        logging.info(log)
+    return message, status
+
+
+def check_plate_in_vehicles_db(
+    plate: str | None, csv_db: dict[str, dict[str, str]]
+) -> tuple[bool, dict[str, str] | None]:
+    """Check if plate exists in database. Returns (found, vehicle_info)."""
+    if not plate:
+        return False, None
+
+    vehicle_info = csv_db.get(plate.upper())
+    return vehicle_info is not None, vehicle_info

--- a/webhooks/middleware/protocols/front_rear_test.py
+++ b/webhooks/middleware/protocols/front_rear_test.py
@@ -533,7 +533,7 @@ class TestWebhookProcessing:
         }
         _response, status = front_rear.process_request(webhook_data)
 
-        assert status == 200
+        assert status == 202
         assert pair.front_event is not None
         assert pair.front_event.camera_id == "camera-front"
 
@@ -561,6 +561,7 @@ class TestWebhookProcessing:
     def test_process_request_authentication_not_configured(
         self, reset_front_rear_state, monkeypatch, mock_config
     ):
+        """With empty tokens list, any token fails comparison and returns 403."""
         monkeypatch.delenv("STREAM_API_TOKENS", raising=False)
         front_rear._stream_api_tokens = []
 
@@ -570,8 +571,8 @@ class TestWebhookProcessing:
         }
         response, status = front_rear.process_request(webhook_data)
 
-        assert status == 401
-        assert "not configured" in response
+        assert status == 403
+        assert "Forbidden" in response
 
     def test_process_request_authentication_malformed_header(
         self, reset_front_rear_state, mock_env_tokens, mock_config
@@ -604,7 +605,7 @@ class TestWebhookProcessing:
         }
         _response, status = front_rear.process_request(webhook_data)
 
-        assert status == 200
+        assert status == 202
 
     def test_process_request_authentication_multiple_valid_tokens(
         self, reset_front_rear_state, mock_env_tokens, mock_config
@@ -625,7 +626,7 @@ class TestWebhookProcessing:
             },
         }
         _response, status = front_rear.process_request(webhook_data_1)
-        assert status == 200
+        assert status == 202
 
         # Test second token
         webhook_data_2 = {
@@ -637,7 +638,7 @@ class TestWebhookProcessing:
             },
         }
         _response, status = front_rear.process_request(webhook_data_2)
-        assert status == 200
+        assert status == 202
 
     def test_process_request_camera_not_in_pair(
         self, reset_front_rear_state, mock_env_tokens, mock_config
@@ -659,7 +660,7 @@ class TestWebhookProcessing:
 
         response, status = front_rear.process_request(webhook_data)
 
-        assert status == 200
+        assert status == 404
         assert "not configured" in response
 
     def test_process_request_buffering(
@@ -680,7 +681,7 @@ class TestWebhookProcessing:
         }
         response, status = front_rear.process_request(webhook_data)
 
-        assert status == 200
+        assert status == 202
         assert "buffered" in response.lower()
         assert pair.front_event is not None
 
@@ -761,7 +762,7 @@ class TestWebhookProcessing:
             }
             response, status = front_rear.process_request(webhook_data)
 
-            assert status == 200
+            assert status == 202
             mock_process_events.assert_called_once()
             alert_types = [
                 call[1]["alert_type"] for call in mock_send_alert.call_args_list
@@ -803,10 +804,58 @@ class TestWebhookProcessing:
         }
         response, status = front_rear.process_request(webhook_data)
 
-        assert status == 200
+        assert status == 202
         mock_process_pair.assert_not_called()
         mock_send_alert.assert_not_called()
         assert pair.front_event is not None
+
+    @patch("protocols.front_rear._forward_to_parkpow")
+    @patch("protocols.front_rear._send_alert")
+    def test_process_request_no_rear_plate_missing_front_plate_no_424(
+        self,
+        mock_send_alert,
+        mock_forward,
+        reset_front_rear_state,
+        create_camera_event,
+        mock_asyncio_for_alerts,
+        mock_env_tokens,
+        mock_config,
+    ):
+        """If ParkPow already created a visit, this flow must not return 424."""
+        mock_forward.return_value = 321
+
+        pair = front_rear.CameraPair(
+            front="camera-front", rear="camera-rear", description="Gate 1"
+        )
+        front_rear.camera_pairs = [pair]
+
+        current_time = time.time()
+        pair.front_event = create_camera_event(
+            camera_id="camera-front", plate=None, timestamp_unix=current_time
+        )
+
+        from datetime import datetime
+
+        timestamp_str = datetime.fromtimestamp(current_time).strftime(
+            "%Y-%m-%d %H:%M:%S.%f"
+        )
+
+        webhook_data = {
+            "webhook_header": {"Authorization": "test-stream-token"},
+            "data": {
+                "camera_id": "camera-rear",
+                "results": [{"plate": None}],
+                "timestamp": timestamp_str,
+            },
+        }
+
+        response, status = front_rear.process_request(webhook_data)
+
+        assert status == 200
+        assert "Processed camera pair" in response
+        mock_forward.assert_called_once()
+        alert_types = [call[1]["alert_type"] for call in mock_send_alert.call_args_list]
+        assert "no_rear_plate" in alert_types
 
 
 class TestCameraPairProcessing:
@@ -1076,6 +1125,36 @@ class TestCameraPairProcessing:
         for call in mock_send_alert.call_args_list:
             assert call[1]["visit_id"] == 123
 
+    @patch("protocols.front_rear._forward_to_parkpow")
+    @patch("protocols.front_rear._send_alert")
+    def test_process_events_no_rear_plate_missing_front_plate_keeps_visit_id(
+        self,
+        mock_send_alert,
+        mock_forward,
+        reset_front_rear_state,
+        create_camera_event,
+        mock_asyncio_for_alerts,
+    ):
+        """If ParkPow visit exists, no-rear-plate path must not return None (prevents 424 retries)."""
+        mock_forward.return_value = 123
+        front_rear.config = TEST_CONFIG
+
+        front_event = create_camera_event(camera_id="camera-front", plate=None)
+        rear_event = create_camera_event(
+            camera_id="camera-rear", plate=None, timestamp="2025-11-24T10:00:05Z"
+        )
+
+        visit_id = front_rear._process_events(
+            front_event=front_event,
+            rear_event=rear_event,
+            front_camera_id="camera-front",
+            rear_camera_id="camera-rear",
+        )
+
+        assert visit_id == 123
+        alert_types = [call[1]["alert_type"] for call in mock_send_alert.call_args_list]
+        assert "no_rear_plate" in alert_types
+
 
 class TestCleanupExpiredEvents:
     @patch("protocols.front_rear._load_vehicles_csv")
@@ -1292,6 +1371,364 @@ class TestSoloCameras:
 
             alert_types = [call[1]["alert_type"] for call in mock_alert.call_args_list]
             assert "no_rear_plate" not in alert_types
+
+
+class TestParkPowErrorHandling:
+    """Test ParkPowError propagation through process_request."""
+
+    @patch("protocols.front_rear._process_camera_pair")
+    def test_parkpow_error_propagated_to_stream(
+        self,
+        mock_process_pair,
+        reset_front_rear_state,
+        create_camera_event,
+        mock_env_tokens,
+        mock_config,
+    ):
+        """ParkPowError during pair processing returns ParkPow status and message."""
+        mock_process_pair.side_effect = front_rear.ParkPowError(502, "Bad Gateway")
+        pair = front_rear.CameraPair(
+            front="camera-front", rear="camera-rear", description="Gate 1"
+        )
+        front_rear.camera_pairs = [pair]
+        current_time = time.time()
+        pair.front_event = create_camera_event(timestamp_unix=current_time)
+
+        from datetime import datetime
+
+        timestamp_str = datetime.fromtimestamp(current_time).strftime(
+            "%Y-%m-%d %H:%M:%S.%f"
+        )
+
+        webhook_data = {
+            "webhook_header": {"Authorization": "test-stream-token"},
+            "data": {
+                "camera_id": "camera-rear",
+                "results": [{"plate": "ABC123"}],
+                "timestamp": timestamp_str,
+            },
+        }
+        response, status = front_rear.process_request(webhook_data)
+
+        assert status == 502
+        assert "ParkPow" in response
+        assert "Bad Gateway" in response
+        # Events should be cleared on ParkPowError
+        assert pair.front_event is None
+        assert pair.rear_event is None
+
+    @patch("protocols.front_rear._process_camera_pair")
+    def test_parkpow_422_rejected_scores(
+        self,
+        mock_process_pair,
+        reset_front_rear_state,
+        create_camera_event,
+        mock_env_tokens,
+        mock_config,
+    ):
+        """ParkPow 422 for low confidence scores is returned to Stream."""
+        mock_process_pair.side_effect = front_rear.ParkPowError(
+            422, "Visit rejected due to low confidence scores"
+        )
+        pair = front_rear.CameraPair(
+            front="camera-front", rear="camera-rear", description="Gate 1"
+        )
+        front_rear.camera_pairs = [pair]
+        current_time = time.time()
+        pair.front_event = create_camera_event(timestamp_unix=current_time)
+
+        from datetime import datetime
+
+        timestamp_str = datetime.fromtimestamp(current_time).strftime(
+            "%Y-%m-%d %H:%M:%S.%f"
+        )
+
+        webhook_data = {
+            "webhook_header": {"Authorization": "test-stream-token"},
+            "data": {
+                "camera_id": "camera-rear",
+                "results": [{"plate": "ABC123"}],
+                "timestamp": timestamp_str,
+            },
+        }
+        response, status = front_rear.process_request(webhook_data)
+
+        assert status == 422
+        assert "low confidence" in response.lower()
+
+    @patch("protocols.front_rear._process_camera_pair")
+    def test_parkpow_503_unreachable(
+        self,
+        mock_process_pair,
+        reset_front_rear_state,
+        create_camera_event,
+        mock_env_tokens,
+        mock_config,
+    ):
+        """ParkPow 503 connection error is returned to Stream."""
+        mock_process_pair.side_effect = front_rear.ParkPowError(
+            503, "Connection refused"
+        )
+        pair = front_rear.CameraPair(
+            front="camera-front", rear="camera-rear", description="Gate 1"
+        )
+        front_rear.camera_pairs = [pair]
+        current_time = time.time()
+        pair.front_event = create_camera_event(timestamp_unix=current_time)
+
+        from datetime import datetime
+
+        timestamp_str = datetime.fromtimestamp(current_time).strftime(
+            "%Y-%m-%d %H:%M:%S.%f"
+        )
+
+        webhook_data = {
+            "webhook_header": {"Authorization": "test-stream-token"},
+            "data": {
+                "camera_id": "camera-rear",
+                "results": [{"plate": "ABC123"}],
+                "timestamp": timestamp_str,
+            },
+        }
+        response, status = front_rear.process_request(webhook_data)
+
+        assert status == 503
+        assert "ParkPow" in response
+
+
+class TestNullVisitId:
+    """Test null visit_id (424) response."""
+
+    @patch("protocols.front_rear._process_camera_pair")
+    def test_null_visit_id_returns_424(
+        self,
+        mock_process_pair,
+        reset_front_rear_state,
+        create_camera_event,
+        mock_env_tokens,
+        mock_config,
+    ):
+        """When _process_camera_pair returns None, Stream gets 424."""
+        mock_process_pair.return_value = None
+        pair = front_rear.CameraPair(
+            front="camera-front", rear="camera-rear", description="Gate 1"
+        )
+        front_rear.camera_pairs = [pair]
+        current_time = time.time()
+        pair.front_event = create_camera_event(timestamp_unix=current_time)
+
+        from datetime import datetime
+
+        timestamp_str = datetime.fromtimestamp(current_time).strftime(
+            "%Y-%m-%d %H:%M:%S.%f"
+        )
+
+        webhook_data = {
+            "webhook_header": {"Authorization": "test-stream-token"},
+            "data": {
+                "camera_id": "camera-rear",
+                "results": [{"plate": "ABC123"}],
+                "timestamp": timestamp_str,
+            },
+        }
+        response, status = front_rear.process_request(webhook_data)
+
+        assert status == 424
+        assert "null visit_id" in response.lower()
+        # Events should be cleared
+        assert pair.front_event is None
+        assert pair.rear_event is None
+
+    @patch("protocols.front_rear._process_camera_pair")
+    def test_successful_pair_returns_200(
+        self,
+        mock_process_pair,
+        reset_front_rear_state,
+        create_camera_event,
+        mock_env_tokens,
+        mock_config,
+    ):
+        """Successful pair processing returns 200 with correct message."""
+        mock_process_pair.return_value = 123
+        pair = front_rear.CameraPair(
+            front="camera-front", rear="camera-rear", description="Gate 1"
+        )
+        front_rear.camera_pairs = [pair]
+        current_time = time.time()
+        pair.front_event = create_camera_event(timestamp_unix=current_time)
+
+        from datetime import datetime
+
+        timestamp_str = datetime.fromtimestamp(current_time).strftime(
+            "%Y-%m-%d %H:%M:%S.%f"
+        )
+
+        webhook_data = {
+            "webhook_header": {"Authorization": "test-stream-token"},
+            "data": {
+                "camera_id": "camera-rear",
+                "results": [{"plate": "ABC123"}],
+                "timestamp": timestamp_str,
+            },
+        }
+        response, status = front_rear.process_request(webhook_data)
+
+        assert status == 200
+        assert "Processed camera pair" in response
+
+
+class TestOverwriteParkPowError:
+    """Test ParkPowError during overwrite event processing."""
+
+    @patch("protocols.front_rear._send_alert")
+    @patch("protocols.front_rear._process_events")
+    def test_overwrite_parkpow_error_continues_normally(
+        self,
+        mock_process_events,
+        mock_send_alert,
+        reset_front_rear_state,
+        create_camera_event,
+        mock_asyncio_for_alerts,
+        mock_env_tokens,
+        mock_config,
+    ):
+        """ParkPowError during overwrite processing doesn't block the main request."""
+        mock_process_events.side_effect = front_rear.ParkPowError(
+            503, "Connection refused"
+        )
+        pair = front_rear.CameraPair(
+            front="camera-front", rear="camera-rear", description="Gate 1"
+        )
+        front_rear.camera_pairs = [pair]
+        old_time = time.time() - 20
+        pair.front_event = create_camera_event(
+            plate="OLD123", timestamp="2024-11-24T10:00:00Z", timestamp_unix=old_time
+        )
+
+        webhook_data = {
+            "webhook_header": {"Authorization": "test-stream-token"},
+            "data": {
+                "camera_id": "camera-front",
+                "results": [{"plate": "NEW456"}],
+                "timestamp": "2024-11-24T10:00:20Z",
+            },
+        }
+        response, status = front_rear.process_request(webhook_data)
+
+        # Main request continues with 202 buffered despite overwrite error
+        assert status == 202
+        # No camera_offline alert since visit_id is None from exception
+        alert_types = [call[1]["alert_type"] for call in mock_send_alert.call_args_list]
+        assert "camera_offline" not in alert_types
+        # New event should still be stored
+        assert pair.front_event is not None
+        assert pair.front_event.results[0]["plate"] == "NEW456"
+
+
+class TestShortHelper:
+    """Test _short camera ID helper."""
+
+    def test_short_none(self):
+        assert front_rear._short(None) == ""
+
+    def test_short_empty(self):
+        assert front_rear._short("") == ""
+
+    def test_short_short_id(self):
+        assert front_rear._short("cam1") == "cam1"
+
+    def test_short_medium_id(self):
+        camera_id = "a" * 59
+        assert front_rear._short(camera_id) == camera_id
+
+    def test_short_long_id(self):
+        camera_id = "a" * 60
+        result = front_rear._short(camera_id)
+        assert result.startswith("...")
+        assert len(result) == 15  # "..." + 12 chars
+
+
+class TestStreamResponse:
+    """Test _stream_response helper."""
+
+    def test_returns_message_and_status(self):
+        msg, status = front_rear._stream_response("test message", 200)
+        assert msg == "test message"
+        assert status == 200
+
+    def test_logs_error_for_5xx(self):
+        with patch("protocols.front_rear.logging.error") as mock_log:
+            front_rear._stream_response("Server Error", 500)
+            mock_log.assert_called_once()
+
+    def test_logs_warning_for_4xx(self):
+        with patch("protocols.front_rear.logging.warning") as mock_log:
+            front_rear._stream_response("Not Found", 404)
+            mock_log.assert_called_once()
+
+    def test_logs_info_for_2xx(self):
+        with patch("protocols.front_rear.logging.info") as mock_log:
+            front_rear._stream_response("OK", 200)
+            mock_log.assert_called_once()
+
+    def test_includes_camera_id_in_log(self):
+        with patch("protocols.front_rear.logging.info") as mock_log:
+            front_rear._stream_response("OK", 200, camera_id="cam1")
+            assert "cam1" in mock_log.call_args[0][0]
+
+
+class TestParkPowErrorException:
+    """Test ParkPowError exception class."""
+
+    def test_attributes(self):
+        err = front_rear.ParkPowError(502, "Bad Gateway")
+        assert err.status == 502
+        assert err.message == "Bad Gateway"
+        assert str(err) == "Bad Gateway"
+
+    def test_is_exception(self):
+        err = front_rear.ParkPowError(500, "Internal")
+        assert isinstance(err, Exception)
+
+
+class TestInitializeValidation:
+    """Test initialization validation of STREAM_API_TOKENS."""
+
+    @patch("protocols.front_rear.asyncio.run_coroutine_threadsafe")
+    @patch("protocols.front_rear.threading.Thread")
+    def test_initialize_empty_stream_tokens_raises(
+        self,
+        mock_thread,
+        mock_run_coro,
+        reset_front_rear_state,
+        sample_config,
+        monkeypatch,
+    ):
+        """Initialization fails if STREAM_API_TOKENS env var has no valid tokens."""
+        monkeypatch.chdir(Path(sample_config).parent.parent.parent)
+        monkeypatch.setenv("PARKPOW_TOKEN", "test-token")
+        monkeypatch.setenv("STREAM_API_TOKENS", "  ,  , ")
+
+        with pytest.raises(ValueError, match="at least one valid token"):
+            front_rear.initialize()
+
+    @patch("protocols.front_rear.asyncio.run_coroutine_threadsafe")
+    @patch("protocols.front_rear.threading.Thread")
+    def test_initialize_missing_stream_tokens_raises(
+        self,
+        mock_thread,
+        mock_run_coro,
+        reset_front_rear_state,
+        sample_config,
+        monkeypatch,
+    ):
+        """Initialization fails if STREAM_API_TOKENS env var is missing."""
+        monkeypatch.chdir(Path(sample_config).parent.parent.parent)
+        monkeypatch.setenv("PARKPOW_TOKEN", "test-token")
+        monkeypatch.delenv("STREAM_API_TOKENS", raising=False)
+
+        with pytest.raises(ValueError, match="STREAM_API_TOKENS"):
+            front_rear.initialize()
 
 
 if __name__ == "__main__":

--- a/webhooks/middleware/protocols/front_rear_test.py
+++ b/webhooks/middleware/protocols/front_rear_test.py
@@ -15,9 +15,11 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from protocols import front_rear_helpers as h
+
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-import protocols.front_rear as front_rear
+import protocols.front_rear as fr
 
 
 def close_coroutine(coro):
@@ -65,17 +67,17 @@ def mock_env_tokens(monkeypatch):
     """Mock environment variables for tokens and set cached token variables."""
     monkeypatch.setenv("STREAM_API_TOKENS", "test-stream-token,another-valid-token")
     monkeypatch.setenv("PARKPOW_TOKEN", "test-parkpow-token")
-    front_rear._stream_api_tokens = ["test-stream-token", "another-valid-token"]
-    front_rear._parkpow_token = "test-parkpow-token"
+    fr._stream_api_tokens = ["test-stream-token", "another-valid-token"]
+    fr._parkpow_token = "test-parkpow-token"
 
 
 @pytest.fixture
 def mock_config():
     """Mock config cache and file modification time to prevent file system access."""
-    front_rear._config_cache = TEST_CONFIG
-    front_rear._config_last_load = time.time()
-    front_rear.config = TEST_CONFIG
-    with patch("os.path.getmtime", return_value=front_rear._config_last_load - 1):
+    fr._config_cache = TEST_CONFIG
+    fr._config_last_load = time.time()
+    fr.config = TEST_CONFIG
+    with patch("os.path.getmtime", return_value=fr._config_last_load - 1):
         yield
 
 
@@ -96,7 +98,7 @@ def create_camera_event():
         if model_make:
             results[0]["model_make"] = model_make
 
-        return front_rear.CameraEvent(
+        return fr.CameraEvent(
             camera_id=camera_id,
             results=results,
             timestamp=timestamp or "2025-11-24T10:00:00Z",
@@ -189,18 +191,18 @@ def mock_asyncio_for_alerts():
 
 @pytest.fixture
 def reset_front_rear_state():
-    front_rear.csv_vehicles = {}
-    front_rear.camera_pairs = []
-    front_rear.config = {}
-    front_rear._config_cache = None
-    front_rear._config_last_load = 0.0
+    fr.csv_vehicles = {}
+    fr.camera_pairs = []
+    fr.config = {}
+    fr._config_cache = None
+    fr._config_last_load = 0.0
     yield
 
-    front_rear.csv_vehicles = {}
-    front_rear.camera_pairs = []
-    front_rear.config = {}
-    front_rear._config_cache = None
-    front_rear._config_last_load = 0.0
+    fr.csv_vehicles = {}
+    fr.camera_pairs = []
+    fr.config = {}
+    fr._config_cache = None
+    fr._config_last_load = 0.0
 
 
 class TestConfigLoading:
@@ -208,7 +210,7 @@ class TestConfigLoading:
         self, reset_front_rear_state, sample_config, monkeypatch
     ):
         monkeypatch.chdir(Path(sample_config).parent.parent.parent)
-        config = front_rear._load_config()
+        config = fr._load_config()
 
         assert "camera_pairs" in config
         assert len(config["camera_pairs"]) == 1
@@ -220,8 +222,8 @@ class TestConfigLoading:
     ):
         monkeypatch.chdir(Path(sample_config).parent.parent.parent)
 
-        config1 = front_rear._load_config()
-        config2 = front_rear._load_config()
+        config1 = fr._load_config()
+        config2 = fr._load_config()
 
         assert config1 is config2
 
@@ -231,7 +233,7 @@ class TestConfigLoading:
         monkeypatch.chdir(tmp_path)
 
         with patch("protocols.front_rear.logging.error") as mock_log:
-            config = front_rear._load_config()
+            config = fr._load_config()
 
             assert config == {}
             mock_log.assert_called_once()
@@ -243,12 +245,12 @@ class TestCSVLoading:
         self, reset_front_rear_state, sample_config, monkeypatch
     ):
         monkeypatch.chdir(Path(sample_config).parent.parent.parent)
-        front_rear._load_vehicles_csv()
+        fr._load_vehicles_csv()
 
-        assert len(front_rear.csv_vehicles) == 3
-        assert "ABC123" in front_rear.csv_vehicles
-        assert front_rear.csv_vehicles["ABC123"]["make"] == "TOYOTA"
-        assert front_rear.csv_vehicles["ABC123"]["model"] == "CAMRY"
+        assert len(fr.csv_vehicles) == 3
+        assert "ABC123" in fr.csv_vehicles
+        assert fr.csv_vehicles["ABC123"]["make"] == "TOYOTA"
+        assert fr.csv_vehicles["ABC123"]["model"] == "CAMRY"
 
     def test_load_front_rear_csv_empty_file(
         self, reset_front_rear_state, tmp_path, monkeypatch
@@ -268,7 +270,7 @@ class TestCSVLoading:
         monkeypatch.chdir(tmp_path)
 
         with pytest.raises(ValueError, match="Front-Rear database is empty"):
-            front_rear._load_vehicles_csv()
+            fr._load_vehicles_csv()
 
     def test_load_front_rear_csv_file_not_found(
         self, reset_front_rear_state, tmp_path, monkeypatch
@@ -286,7 +288,7 @@ class TestCSVLoading:
         monkeypatch.chdir(tmp_path)
 
         with pytest.raises(FileNotFoundError):
-            front_rear._load_vehicles_csv()
+            fr._load_vehicles_csv()
 
 
 class TestCameraPairLookup:
@@ -297,37 +299,37 @@ class TestCameraPairLookup:
 
     @pytest.mark.parametrize("camera_id", ["cam1", "cam2"])
     def test_get_camera_pair(self, reset_front_rear_state, camera_id):
-        front_rear.camera_pairs = [
-            front_rear.CameraPair(
+        fr.camera_pairs = [
+            fr.CameraPair(
                 front=p["front"], rear=p["rear"], description=p["description"]
             )
             for p in self.pairs
         ]
-        pair = front_rear._get_camera_pair(camera_id)
+        pair = fr._get_camera_pair(camera_id)
 
         assert pair is not None
         assert pair.front == "cam1"
         assert pair.rear == "cam2"
 
     def test_get_camera_pair_not_found(self, reset_front_rear_state):
-        front_rear.camera_pairs = [
-            front_rear.CameraPair(
+        fr.camera_pairs = [
+            fr.CameraPair(
                 front=p["front"], rear=p["rear"], description=p["description"]
             )
             for p in self.pairs
         ]
-        pair = front_rear._get_camera_pair("cam5")
+        pair = fr._get_camera_pair("cam5")
 
         assert pair is None
 
     def test_get_camera_pair_multiple_pairs(self, reset_front_rear_state):
-        front_rear.camera_pairs = [
-            front_rear.CameraPair(
+        fr.camera_pairs = [
+            fr.CameraPair(
                 front=p["front"], rear=p["rear"], description=p["description"]
             )
             for p in self.pairs
         ]
-        pair = front_rear._get_camera_pair("cam3")
+        pair = fr._get_camera_pair("cam3")
 
         assert pair is not None
         assert pair.description == "Gate 2"
@@ -341,7 +343,7 @@ class TestPlateExtraction:
         self, reset_front_rear_state, input_plate, expected
     ):
         result = {"plate": input_plate}
-        plate = front_rear._extract_plate(result)
+        plate = h.extract_plate(result)
 
         assert plate == expected
 
@@ -354,7 +356,7 @@ class TestPlateExtraction:
         ],
     )
     def test_extract_plate_invalid_cases(self, reset_front_rear_state, result):
-        plate = front_rear._extract_plate(result)
+        plate = h.extract_plate(result)
 
         assert plate is None
 
@@ -364,7 +366,7 @@ class TestMakeModelExtraction:
         results = [
             {"model_make": [{"make": "TOYOTA", "model": "CAMRY", "score": 0.85}]}
         ]
-        make_model, score = front_rear._extract_best_make_model(results)
+        make_model, score = h.extract_best_make_model(results)
 
         assert make_model == "TOYOTA CAMRY"
         assert score == 0.85
@@ -379,7 +381,7 @@ class TestMakeModelExtraction:
                 ]
             }
         ]
-        make_model, score = front_rear._extract_best_make_model(results)
+        make_model, score = h.extract_best_make_model(results)
 
         assert make_model == "HONDA ACCORD"
         assert score == 0.85
@@ -389,21 +391,21 @@ class TestMakeModelExtraction:
             {"model_make": [{"make": "TOYOTA", "model": "CAMRY", "score": 0.65}]},
             {"model_make": [{"make": "HONDA", "model": "ACCORD", "score": 0.85}]},
         ]
-        make_model, score = front_rear._extract_best_make_model(results)
+        make_model, score = h.extract_best_make_model(results)
 
         assert make_model == "HONDA ACCORD"
         assert score == 0.85
 
     def test_extract_best_make_model_empty_results(self, reset_front_rear_state):
         results = []
-        make_model, score = front_rear._extract_best_make_model(results)
+        make_model, score = h.extract_best_make_model(results)
 
         assert make_model is None
         assert score == 0.0
 
     def test_extract_best_make_model_no_detections(self, reset_front_rear_state):
         results = [{"model_make": []}]
-        make_model, score = front_rear._extract_best_make_model(results)
+        make_model, score = h.extract_best_make_model(results)
 
         assert make_model is None
         assert score == 0.0
@@ -412,7 +414,7 @@ class TestMakeModelExtraction:
         results = [
             {"model_make": [{"make": "TOYOTA", "score": 0.85}]}  # Missing model
         ]
-        make_model, score = front_rear._extract_best_make_model(results)
+        make_model, score = h.extract_best_make_model(results)
 
         assert make_model == "TOYOTA"
         assert score == 0.85
@@ -420,8 +422,8 @@ class TestMakeModelExtraction:
 
 class TestPlateDatabase:
     def test_check_plate_in_db_found(self, reset_front_rear_state):
-        front_rear.csv_vehicles = {"ABC123": {"make": "TOYOTA", "model": "CAMRY"}}
-        found, vehicle_info = front_rear._check_plate_in_vehicles_db("ABC123")
+        fr.csv_vehicles = {"ABC123": {"make": "TOYOTA", "model": "CAMRY"}}
+        found, vehicle_info = h.check_plate_in_vehicles_db("ABC123", fr.csv_vehicles)
 
         assert found is True
         assert vehicle_info is not None
@@ -430,15 +432,17 @@ class TestPlateDatabase:
 
     @pytest.mark.parametrize("search_plate", ["XYZ999", None])
     def test_check_plate_in_db_not_found(self, reset_front_rear_state, search_plate):
-        front_rear.csv_vehicles = {"ABC123": {"make": "TOYOTA", "model": "CAMRY"}}
-        found, vehicle_info = front_rear._check_plate_in_vehicles_db(search_plate)
+        fr.csv_vehicles = {"ABC123": {"make": "TOYOTA", "model": "CAMRY"}}
+        found, vehicle_info = h.check_plate_in_vehicles_db(
+            search_plate, fr.csv_vehicles
+        )
 
         assert found is False
         assert vehicle_info is None
 
     def test_check_plate_in_db_case_insensitive(self, reset_front_rear_state):
-        front_rear.csv_vehicles = {"ABC123": {"make": "TOYOTA", "model": "CAMRY"}}
-        found, vehicle_info = front_rear._check_plate_in_vehicles_db("abc123")
+        fr.csv_vehicles = {"ABC123": {"make": "TOYOTA", "model": "CAMRY"}}
+        found, vehicle_info = h.check_plate_in_vehicles_db("abc123", fr.csv_vehicles)
 
         assert found is True
         assert vehicle_info is not None
@@ -452,9 +456,9 @@ class TestAlertSending:
         ), patch("protocols.front_rear.asyncio.run_coroutine_threadsafe") as mock_run:
             mock_run.side_effect = lambda coro, loop: close_coroutine(coro) or Mock()
 
-            front_rear.config = TEST_CONFIG
+            fr.config = TEST_CONFIG
 
-            front_rear._send_alert(
+            fr._send_alert(
                 alert_type="plate_mismatch",
                 visit_id=456,
                 plate="ABC123",
@@ -472,9 +476,9 @@ class TestAlertSending:
         ), patch("protocols.front_rear.asyncio.run_coroutine_threadsafe") as mock_run:
             mock_run.side_effect = lambda coro, loop: close_coroutine(coro) or Mock()
 
-            front_rear.config = TEST_CONFIG
+            fr.config = TEST_CONFIG
 
-            front_rear._send_alert(
+            fr._send_alert(
                 alert_type="plate_mismatch",
                 visit_id=456,
                 plate="ABC123",
@@ -496,14 +500,14 @@ class TestAlertSending:
                 "alert_template_id": 1,
             }
         }
-        front_rear.config = config_with_disabled
+        fr.config = config_with_disabled
 
         with patch("protocols.front_rear._loop"), patch(
             "protocols.front_rear._aiohttp_session"
         ), patch("protocols.front_rear.asyncio.run_coroutine_threadsafe") as mock_run:
             mock_run.side_effect = lambda coro, loop: close_coroutine(coro) or Mock()
 
-            front_rear._send_alert(
+            fr._send_alert(
                 alert_type="plate_mismatch",
                 visit_id=456,
                 plate="ABC123",
@@ -518,10 +522,10 @@ class TestWebhookProcessing:
     def test_process_request_authentication_success(
         self, reset_front_rear_state, mock_env_tokens, mock_config
     ):
-        pair = front_rear.CameraPair(
+        pair = fr.CameraPair(
             front="camera-front", rear="camera-rear", description="Gate 1"
         )
-        front_rear.camera_pairs = [pair]
+        fr.camera_pairs = [pair]
 
         webhook_data = {
             "webhook_header": {"Authorization": "test-stream-token"},
@@ -531,7 +535,7 @@ class TestWebhookProcessing:
                 "timestamp": "2025-11-24T10:00:00Z",
             },
         }
-        _response, status = front_rear.process_request(webhook_data)
+        _response, status = fr.process_request(webhook_data)
 
         assert status == 202
         assert pair.front_event is not None
@@ -541,7 +545,7 @@ class TestWebhookProcessing:
         self, reset_front_rear_state, mock_env_tokens, mock_config
     ):
         webhook_data = {"webhook_header": {}, "data": {"camera_id": "camera-front"}}
-        response, status = front_rear.process_request(webhook_data)
+        response, status = fr.process_request(webhook_data)
 
         assert status == 401
         assert "Unauthorized" in response
@@ -553,7 +557,7 @@ class TestWebhookProcessing:
             "webhook_header": {"Authorization": "wrong-token"},
             "data": {"camera_id": "camera-front"},
         }
-        response, status = front_rear.process_request(webhook_data)
+        response, status = fr.process_request(webhook_data)
 
         assert status == 403
         assert "Forbidden" in response
@@ -563,13 +567,13 @@ class TestWebhookProcessing:
     ):
         """With empty tokens list, any token fails comparison and returns 403."""
         monkeypatch.delenv("STREAM_API_TOKENS", raising=False)
-        front_rear._stream_api_tokens = []
+        fr._stream_api_tokens = []
 
         webhook_data = {
             "webhook_header": {"Authorization": "any-token"},
             "data": {"camera_id": "camera-front"},
         }
-        response, status = front_rear.process_request(webhook_data)
+        response, status = fr.process_request(webhook_data)
 
         assert status == 403
         assert "Forbidden" in response
@@ -581,7 +585,7 @@ class TestWebhookProcessing:
             "webhook_header": {"Authorization": "Token "},
             "data": {"camera_id": "camera-front"},
         }
-        response, status = front_rear.process_request(webhook_data)
+        response, status = fr.process_request(webhook_data)
 
         assert status == 401
         assert "Malformed" in response
@@ -589,8 +593,8 @@ class TestWebhookProcessing:
     def test_process_request_authentication_token_with_prefix(
         self, reset_front_rear_state, mock_env_tokens, mock_config
     ):
-        front_rear.camera_pairs = [
-            front_rear.CameraPair(
+        fr.camera_pairs = [
+            fr.CameraPair(
                 front="camera-front", rear="camera-rear", description="Gate 1"
             )
         ]
@@ -603,7 +607,7 @@ class TestWebhookProcessing:
                 "timestamp": "2025-11-24T10:00:00Z",
             },
         }
-        _response, status = front_rear.process_request(webhook_data)
+        _response, status = fr.process_request(webhook_data)
 
         assert status == 202
 
@@ -611,10 +615,10 @@ class TestWebhookProcessing:
         self, reset_front_rear_state, mock_env_tokens, mock_config
     ):
         """Test that any token from the valid tokens list is accepted."""
-        pair = front_rear.CameraPair(
+        pair = fr.CameraPair(
             front="camera-front", rear="camera-rear", description="Gate 1"
         )
-        front_rear.camera_pairs = [pair]
+        fr.camera_pairs = [pair]
 
         # Test first token
         webhook_data_1 = {
@@ -625,7 +629,7 @@ class TestWebhookProcessing:
                 "timestamp": "2025-11-24T10:00:00Z",
             },
         }
-        _response, status = front_rear.process_request(webhook_data_1)
+        _response, status = fr.process_request(webhook_data_1)
         assert status == 202
 
         # Test second token
@@ -637,14 +641,14 @@ class TestWebhookProcessing:
                 "timestamp": "2025-11-24T10:00:01Z",
             },
         }
-        _response, status = front_rear.process_request(webhook_data_2)
+        _response, status = fr.process_request(webhook_data_2)
         assert status == 202
 
     def test_process_request_camera_not_in_pair(
         self, reset_front_rear_state, mock_env_tokens, mock_config
     ):
-        front_rear.camera_pairs = [
-            front_rear.CameraPair(
+        fr.camera_pairs = [
+            fr.CameraPair(
                 front="camera-front", rear="camera-rear", description="Gate 1"
             )
         ]
@@ -658,7 +662,7 @@ class TestWebhookProcessing:
             },
         }
 
-        response, status = front_rear.process_request(webhook_data)
+        response, status = fr.process_request(webhook_data)
 
         assert status == 404
         assert "not configured" in response
@@ -666,10 +670,10 @@ class TestWebhookProcessing:
     def test_process_request_buffering(
         self, reset_front_rear_state, mock_env_tokens, mock_config
     ):
-        pair = front_rear.CameraPair(
+        pair = fr.CameraPair(
             front="camera-front", rear="camera-rear", description="Gate 1"
         )
-        front_rear.camera_pairs = [pair]
+        fr.camera_pairs = [pair]
 
         webhook_data = {
             "webhook_header": {"Authorization": "test-stream-token"},
@@ -679,7 +683,7 @@ class TestWebhookProcessing:
                 "timestamp": "2025-11-24T10:00:00Z",
             },
         }
-        response, status = front_rear.process_request(webhook_data)
+        response, status = fr.process_request(webhook_data)
 
         assert status == 202
         assert "buffered" in response.lower()
@@ -694,10 +698,10 @@ class TestWebhookProcessing:
         mock_env_tokens,
         mock_config,
     ):
-        pair = front_rear.CameraPair(
+        pair = fr.CameraPair(
             front="camera-front", rear="camera-rear", description="Gate 1"
         )
-        front_rear.camera_pairs = [pair]
+        fr.camera_pairs = [pair]
         current_time = time.time()
         pair.front_event = create_camera_event(
             timestamp="2024-11-24T10:00:00Z", timestamp_unix=current_time
@@ -717,7 +721,7 @@ class TestWebhookProcessing:
                 "timestamp": timestamp_str,
             },
         }
-        _response, status = front_rear.process_request(webhook_data)
+        _response, status = fr.process_request(webhook_data)
 
         assert status == 200
         mock_process_pair.assert_called_once()
@@ -741,10 +745,10 @@ class TestWebhookProcessing:
         with patch(
             "protocols.front_rear._process_events", return_value=123
         ) as mock_process_events:
-            pair = front_rear.CameraPair(
+            pair = fr.CameraPair(
                 front="camera-front", rear="camera-rear", description="Gate 1"
             )
-            front_rear.camera_pairs = [pair]
+            fr.camera_pairs = [pair]
             old_time = time.time() - 20
             pair.front_event = create_camera_event(
                 plate="OLD123",
@@ -760,7 +764,7 @@ class TestWebhookProcessing:
                     "timestamp": "2024-11-24T10:00:20Z",
                 },
             }
-            response, status = front_rear.process_request(webhook_data)
+            response, status = fr.process_request(webhook_data)
 
             assert status == 202
             mock_process_events.assert_called_once()
@@ -785,10 +789,10 @@ class TestWebhookProcessing:
         mock_config,
     ):
         """Test that updating with same plate does not trigger overwrite alert."""
-        pair = front_rear.CameraPair(
+        pair = fr.CameraPair(
             front="camera-front", rear="camera-rear", description="Gate 1"
         )
-        front_rear.camera_pairs = [pair]
+        fr.camera_pairs = [pair]
         old_time = time.time() - 5
         pair.front_event = create_camera_event(
             plate="ABC123", timestamp="2024-11-24T10:00:00Z", timestamp_unix=old_time
@@ -802,7 +806,7 @@ class TestWebhookProcessing:
                 "timestamp": "2024-11-24T10:00:05Z",
             },
         }
-        response, status = front_rear.process_request(webhook_data)
+        response, status = fr.process_request(webhook_data)
 
         assert status == 202
         mock_process_pair.assert_not_called()
@@ -824,10 +828,10 @@ class TestWebhookProcessing:
         """If ParkPow already created a visit, this flow must not return 424."""
         mock_forward.return_value = 321
 
-        pair = front_rear.CameraPair(
+        pair = fr.CameraPair(
             front="camera-front", rear="camera-rear", description="Gate 1"
         )
-        front_rear.camera_pairs = [pair]
+        fr.camera_pairs = [pair]
 
         current_time = time.time()
         pair.front_event = create_camera_event(
@@ -849,7 +853,7 @@ class TestWebhookProcessing:
             },
         }
 
-        response, status = front_rear.process_request(webhook_data)
+        response, status = fr.process_request(webhook_data)
 
         assert status == 200
         assert "Processed camera pair" in response
@@ -870,22 +874,22 @@ class TestCameraPairProcessing:
         mock_asyncio_for_alerts,
     ):
         mock_forward.return_value = 123
-        front_rear.csv_vehicles = {}
-        front_rear.config = TEST_CONFIG
+        fr.csv_vehicles = {}
+        fr.config = TEST_CONFIG
         front_event = create_camera_event(camera_id="camera-front", plate="UNKNOWN123")
         rear_event = create_camera_event(
             camera_id="camera-rear",
             plate="UNKNOWN123",
             timestamp="2025-11-24T10:00:05Z",
         )
-        pair = front_rear.CameraPair(
+        pair = fr.CameraPair(
             front="camera-front",
             rear="camera-rear",
             description="Gate 1",
             front_event=front_event,
             rear_event=rear_event,
         )
-        front_rear._process_camera_pair(pair)
+        fr._process_camera_pair(pair)
 
         mock_forward.assert_called_once()
         assert mock_send_alert.call_count >= 2
@@ -905,19 +909,19 @@ class TestCameraPairProcessing:
         mock_asyncio_for_alerts,
     ):
         mock_forward.return_value = 123
-        front_rear.config = TEST_CONFIG
+        fr.config = TEST_CONFIG
         front_event = create_camera_event()
         rear_event = create_camera_event(
             camera_id="camera-rear", plate=None, timestamp="2025-11-24T10:00:05Z"
         )
-        pair = front_rear.CameraPair(
+        pair = fr.CameraPair(
             front="camera-front",
             rear="camera-rear",
             description="Gate 1",
             front_event=front_event,
             rear_event=rear_event,
         )
-        front_rear._process_camera_pair(pair)
+        fr._process_camera_pair(pair)
 
         mock_forward.assert_called_once()
         alert_calls = [call[1]["alert_type"] for call in mock_send_alert.call_args_list]
@@ -936,22 +940,22 @@ class TestCameraPairProcessing:
         mock_asyncio_for_alerts,
     ):
         mock_forward.return_value = 123
-        front_rear.csv_vehicles = {"ABC123": {"make": "TOYOTA", "model": "CAMRY"}}
-        front_rear.config = TEST_CONFIG
+        fr.csv_vehicles = {"ABC123": {"make": "TOYOTA", "model": "CAMRY"}}
+        fr.config = TEST_CONFIG
         front_event = create_camera_event(
             model_make=[{"make": "HONDA", "model": "ACCORD", "score": 0.85}]
         )
         rear_event = create_camera_event(
             camera_id="camera-rear", timestamp="2025-11-24T10:00:05Z"
         )
-        pair = front_rear.CameraPair(
+        pair = fr.CameraPair(
             front="camera-front",
             rear="camera-rear",
             description="Gate 1",
             front_event=front_event,
             rear_event=rear_event,
         )
-        front_rear._process_camera_pair(pair)
+        fr._process_camera_pair(pair)
 
         mock_forward.assert_called_once()
         alert_calls = [call[1]["alert_type"] for call in mock_send_alert.call_args_list]
@@ -970,22 +974,22 @@ class TestCameraPairProcessing:
         mock_asyncio_for_alerts,
     ):
         mock_forward.return_value = 123
-        front_rear.csv_vehicles = {"ABC123": {"make": "TOYOTA", "model": "CAMRY"}}
-        front_rear.config = TEST_CONFIG
+        fr.csv_vehicles = {"ABC123": {"make": "TOYOTA", "model": "CAMRY"}}
+        fr.config = TEST_CONFIG
         front_event = create_camera_event()
         rear_event = create_camera_event(
             camera_id="camera-rear",
             timestamp="2025-11-24T10:00:05Z",
             original_json_data={"test": "rear_data"},
         )
-        pair = front_rear.CameraPair(
+        pair = fr.CameraPair(
             front="camera-front",
             rear="camera-rear",
             description="Gate 1",
             front_event=front_event,
             rear_event=rear_event,
         )
-        front_rear._process_camera_pair(pair)
+        fr._process_camera_pair(pair)
 
         mock_forward.assert_called_once()
         call_args = mock_forward.call_args[0]
@@ -1003,17 +1007,17 @@ class TestCameraPairProcessing:
     ):
         """Test that front camera data is forwarded when rear camera is unavailable."""
         mock_forward.return_value = 123
-        front_rear.csv_vehicles = {"ABC123": {"make": "TOYOTA", "model": "CAMRY"}}
-        front_rear.config = TEST_CONFIG
+        fr.csv_vehicles = {"ABC123": {"make": "TOYOTA", "model": "CAMRY"}}
+        fr.config = TEST_CONFIG
         front_event = create_camera_event(original_json_data={"test": "front_data"})
-        pair = front_rear.CameraPair(
+        pair = fr.CameraPair(
             front="camera-front",
             rear="camera-rear",
             description="Gate 1",
             front_event=front_event,
             rear_event=None,
         )
-        front_rear._process_camera_pair(pair)
+        fr._process_camera_pair(pair)
 
         mock_forward.assert_called_once()
         call_args = mock_forward.call_args[0]
@@ -1030,19 +1034,19 @@ class TestCameraPairProcessing:
         mock_asyncio_for_alerts,
     ):
         mock_forward.return_value = 123
-        front_rear.csv_vehicles = {}
-        front_rear.config = TEST_CONFIG
+        fr.csv_vehicles = {}
+        fr.config = TEST_CONFIG
         front_event = create_camera_event(
             plate="UNKNOWN123", original_json_data={"test": "front_data"}
         )
-        pair = front_rear.CameraPair(
+        pair = fr.CameraPair(
             front="camera-front",
             rear="camera-rear",
             description="Gate 1",
             front_event=front_event,
             rear_event=None,
         )
-        front_rear._process_camera_pair(pair)
+        fr._process_camera_pair(pair)
 
         alert_types = [call[1]["alert_type"] for call in mock_send_alert.call_args_list]
         assert "no_rear_plate" not in alert_types
@@ -1063,22 +1067,22 @@ class TestCameraPairProcessing:
     ):
         """Test that single rear camera event validates against database."""
         mock_forward.return_value = 123
-        front_rear.csv_vehicles = {}
-        front_rear.config = TEST_CONFIG
+        fr.csv_vehicles = {}
+        fr.config = TEST_CONFIG
         rear_event = create_camera_event(
             camera_id="camera-rear",
             plate="UNKNOWN123",
             timestamp="2025-11-24T10:00:05Z",
             original_json_data={"test": "rear_data"},
         )
-        pair = front_rear.CameraPair(
+        pair = fr.CameraPair(
             front="camera-front",
             rear="camera-rear",
             description="Gate 1",
             front_event=None,
             rear_event=rear_event,
         )
-        front_rear._process_camera_pair(pair)
+        fr._process_camera_pair(pair)
 
         alert_types = [call[1]["alert_type"] for call in mock_send_alert.call_args_list]
         assert "plate_mismatch" in alert_types
@@ -1101,8 +1105,8 @@ class TestCameraPairProcessing:
     ):
         """Test that no_rear_plate alert is sent when rear camera is online but detects no plate."""
         mock_forward.return_value = 123
-        front_rear.csv_vehicles = {"ABC123": {"make": "TOYOTA", "model": "CAMRY"}}
-        front_rear.config = TEST_CONFIG
+        fr.csv_vehicles = {"ABC123": {"make": "TOYOTA", "model": "CAMRY"}}
+        fr.config = TEST_CONFIG
         front_event = create_camera_event()
         rear_event = create_camera_event(
             camera_id="camera-rear",
@@ -1110,14 +1114,14 @@ class TestCameraPairProcessing:
             timestamp="2025-11-24T10:00:05Z",
             original_json_data={"test": "rear_data"},
         )
-        pair = front_rear.CameraPair(
+        pair = fr.CameraPair(
             front="camera-front",
             rear="camera-rear",
             description="Gate 1",
             front_event=front_event,
             rear_event=rear_event,
         )
-        front_rear._process_camera_pair(pair)
+        fr._process_camera_pair(pair)
 
         mock_forward.assert_called_once()
         alert_types = [call[1]["alert_type"] for call in mock_send_alert.call_args_list]
@@ -1137,14 +1141,14 @@ class TestCameraPairProcessing:
     ):
         """If ParkPow visit exists, no-rear-plate path must not return None (prevents 424 retries)."""
         mock_forward.return_value = 123
-        front_rear.config = TEST_CONFIG
+        fr.config = TEST_CONFIG
 
         front_event = create_camera_event(camera_id="camera-front", plate=None)
         rear_event = create_camera_event(
             camera_id="camera-rear", plate=None, timestamp="2025-11-24T10:00:05Z"
         )
 
-        visit_id = front_rear._process_events(
+        visit_id = fr._process_events(
             front_event=front_event,
             rear_event=rear_event,
             front_camera_id="camera-front",
@@ -1176,14 +1180,14 @@ class TestCleanupExpiredEvents:
         mock_forward.return_value = 123
         mock_process_pair.return_value = 123
         mock_load_config.return_value = TEST_CONFIG
-        front_rear.config = TEST_CONFIG
-        old_pair = front_rear.CameraPair(
+        fr.config = TEST_CONFIG
+        old_pair = fr.CameraPair(
             front="camera-old", rear="camera-old-rear", description="Gate 1"
         )
-        new_pair = front_rear.CameraPair(
+        new_pair = fr.CameraPair(
             front="camera-new", rear="camera-new-rear", description="Gate 2"
         )
-        front_rear.camera_pairs = [old_pair, new_pair]
+        fr.camera_pairs = [old_pair, new_pair]
 
         old_pair.front_event = create_camera_event(
             camera_id="camera-old", timestamp_unix=time.time() - 100
@@ -1191,7 +1195,7 @@ class TestCleanupExpiredEvents:
         new_pair.front_event = create_camera_event(
             camera_id="camera-new", plate="XYZ789", timestamp_unix=time.time() - 10
         )
-        front_rear._cleanup_expired_events()
+        fr._cleanup_expired_events()
 
         mock_process_pair.assert_called_once()
         alert_types = [call[1]["alert_type"] for call in mock_send_alert.call_args_list]
@@ -1228,15 +1232,15 @@ class TestInitialization:
 
         mock_run_coro.side_effect = mock_run_side_effect
 
-        front_rear.initialize()
+        fr.initialize()
 
-        assert len(front_rear.csv_vehicles) > 0
-        assert len(front_rear.camera_pairs) > 0
+        assert len(fr.csv_vehicles) > 0
+        assert len(fr.camera_pairs) > 0
         assert mock_thread.call_count == 2
         for call in mock_thread.call_args_list:
             assert call[1]["daemon"] is True
 
-        assert front_rear._aiohttp_session == mock_session
+        assert fr._aiohttp_session == mock_session
 
 
 class TestSoloCameras:
@@ -1255,14 +1259,14 @@ class TestSoloCameras:
         self, reset_front_rear_state, front, rear, expected_camera_id, expected_id
     ):
         """Test solo camera properties for different configurations."""
-        pair = front_rear.CameraPair(front=front, rear=rear, description="Solo")
+        pair = fr.CameraPair(front=front, rear=rear, description="Solo")
         assert pair.is_solo is True
         assert pair.solo_camera_id == expected_camera_id
         assert pair.id == expected_id
 
     def test_paired_camera_not_solo(self, reset_front_rear_state):
         """Test paired camera is not solo."""
-        pair = front_rear.CameraPair(front="cam1", rear="cam2", description="Paired")
+        pair = fr.CameraPair(front="cam1", rear="cam2", description="Paired")
         assert pair.is_solo is False
         assert pair.solo_camera_id is None
         assert pair.id == "cam1:cam2"
@@ -1276,10 +1280,8 @@ class TestSoloCameras:
     )
     def test_get_camera_pair_solo(self, reset_front_rear_state, front, rear, camera_id):
         """Test finding solo cameras in either position."""
-        front_rear.camera_pairs = [
-            front_rear.CameraPair(front=front, rear=rear, description="Solo")
-        ]
-        pair = front_rear._get_camera_pair(camera_id)
+        fr.camera_pairs = [fr.CameraPair(front=front, rear=rear, description="Solo")]
+        pair = fr._get_camera_pair(camera_id)
         assert pair is not None
         assert pair.is_solo is True
 
@@ -1313,12 +1315,12 @@ class TestSoloCameras:
         mock_forward.return_value = visit_id
 
         if should_have_plate_in_db:
-            front_rear.csv_vehicles = {plate: {"make": "TOYOTA", "model": "CAMRY"}}
+            fr.csv_vehicles = {plate: {"make": "TOYOTA", "model": "CAMRY"}}
         else:
-            front_rear.csv_vehicles = {}
+            fr.csv_vehicles = {}
 
-        pair = front_rear.CameraPair(front=front, rear=rear, description="Solo")
-        front_rear.camera_pairs = [pair]
+        pair = fr.CameraPair(front=front, rear=rear, description="Solo")
+        fr.camera_pairs = [pair]
 
         webhook_data = {
             "webhook_header": {"Authorization": "test-stream-token"},
@@ -1329,7 +1331,7 @@ class TestSoloCameras:
             },
         }
 
-        response, status = front_rear.process_request(webhook_data)
+        response, status = fr.process_request(webhook_data)
 
         assert status == 200
         assert "Processed" in response
@@ -1353,9 +1355,9 @@ class TestSoloCameras:
     ):
         """Test solo camera does not trigger no_rear_plate alert."""
         mock_forward.return_value = 999
-        front_rear.csv_vehicles = {}
-        pair = front_rear.CameraPair(front="solo-cam", rear=None, description="Solo")
-        front_rear.camera_pairs = [pair]
+        fr.csv_vehicles = {}
+        pair = fr.CameraPair(front="solo-cam", rear=None, description="Solo")
+        fr.camera_pairs = [pair]
 
         with patch("protocols.front_rear._send_alert") as mock_alert:
             webhook_data = {
@@ -1367,7 +1369,7 @@ class TestSoloCameras:
                 },
             }
 
-            front_rear.process_request(webhook_data)
+            fr.process_request(webhook_data)
 
             alert_types = [call[1]["alert_type"] for call in mock_alert.call_args_list]
             assert "no_rear_plate" not in alert_types
@@ -1386,11 +1388,11 @@ class TestParkPowErrorHandling:
         mock_config,
     ):
         """ParkPowError during pair processing returns ParkPow status and message."""
-        mock_process_pair.side_effect = front_rear.ParkPowError(502, "Bad Gateway")
-        pair = front_rear.CameraPair(
+        mock_process_pair.side_effect = fr.ParkPowError(502, "Bad Gateway")
+        pair = fr.CameraPair(
             front="camera-front", rear="camera-rear", description="Gate 1"
         )
-        front_rear.camera_pairs = [pair]
+        fr.camera_pairs = [pair]
         current_time = time.time()
         pair.front_event = create_camera_event(timestamp_unix=current_time)
 
@@ -1408,7 +1410,7 @@ class TestParkPowErrorHandling:
                 "timestamp": timestamp_str,
             },
         }
-        response, status = front_rear.process_request(webhook_data)
+        response, status = fr.process_request(webhook_data)
 
         assert status == 502
         assert "ParkPow" in response
@@ -1427,13 +1429,13 @@ class TestParkPowErrorHandling:
         mock_config,
     ):
         """ParkPow 422 for low confidence scores is returned to Stream."""
-        mock_process_pair.side_effect = front_rear.ParkPowError(
+        mock_process_pair.side_effect = fr.ParkPowError(
             422, "Visit rejected due to low confidence scores"
         )
-        pair = front_rear.CameraPair(
+        pair = fr.CameraPair(
             front="camera-front", rear="camera-rear", description="Gate 1"
         )
-        front_rear.camera_pairs = [pair]
+        fr.camera_pairs = [pair]
         current_time = time.time()
         pair.front_event = create_camera_event(timestamp_unix=current_time)
 
@@ -1451,7 +1453,7 @@ class TestParkPowErrorHandling:
                 "timestamp": timestamp_str,
             },
         }
-        response, status = front_rear.process_request(webhook_data)
+        response, status = fr.process_request(webhook_data)
 
         assert status == 422
         assert "low confidence" in response.lower()
@@ -1466,13 +1468,11 @@ class TestParkPowErrorHandling:
         mock_config,
     ):
         """ParkPow 503 connection error is returned to Stream."""
-        mock_process_pair.side_effect = front_rear.ParkPowError(
-            503, "Connection refused"
-        )
-        pair = front_rear.CameraPair(
+        mock_process_pair.side_effect = fr.ParkPowError(503, "Connection refused")
+        pair = fr.CameraPair(
             front="camera-front", rear="camera-rear", description="Gate 1"
         )
-        front_rear.camera_pairs = [pair]
+        fr.camera_pairs = [pair]
         current_time = time.time()
         pair.front_event = create_camera_event(timestamp_unix=current_time)
 
@@ -1490,7 +1490,7 @@ class TestParkPowErrorHandling:
                 "timestamp": timestamp_str,
             },
         }
-        response, status = front_rear.process_request(webhook_data)
+        response, status = fr.process_request(webhook_data)
 
         assert status == 503
         assert "ParkPow" in response
@@ -1510,10 +1510,10 @@ class TestNullVisitId:
     ):
         """When _process_camera_pair returns None, Stream gets 424."""
         mock_process_pair.return_value = None
-        pair = front_rear.CameraPair(
+        pair = fr.CameraPair(
             front="camera-front", rear="camera-rear", description="Gate 1"
         )
-        front_rear.camera_pairs = [pair]
+        fr.camera_pairs = [pair]
         current_time = time.time()
         pair.front_event = create_camera_event(timestamp_unix=current_time)
 
@@ -1531,7 +1531,7 @@ class TestNullVisitId:
                 "timestamp": timestamp_str,
             },
         }
-        response, status = front_rear.process_request(webhook_data)
+        response, status = fr.process_request(webhook_data)
 
         assert status == 424
         assert "null visit_id" in response.lower()
@@ -1550,10 +1550,10 @@ class TestNullVisitId:
     ):
         """Successful pair processing returns 200 with correct message."""
         mock_process_pair.return_value = 123
-        pair = front_rear.CameraPair(
+        pair = fr.CameraPair(
             front="camera-front", rear="camera-rear", description="Gate 1"
         )
-        front_rear.camera_pairs = [pair]
+        fr.camera_pairs = [pair]
         current_time = time.time()
         pair.front_event = create_camera_event(timestamp_unix=current_time)
 
@@ -1571,7 +1571,7 @@ class TestNullVisitId:
                 "timestamp": timestamp_str,
             },
         }
-        response, status = front_rear.process_request(webhook_data)
+        response, status = fr.process_request(webhook_data)
 
         assert status == 200
         assert "Processed camera pair" in response
@@ -1593,13 +1593,11 @@ class TestOverwriteParkPowError:
         mock_config,
     ):
         """ParkPowError during overwrite processing doesn't block the main request."""
-        mock_process_events.side_effect = front_rear.ParkPowError(
-            503, "Connection refused"
-        )
-        pair = front_rear.CameraPair(
+        mock_process_events.side_effect = fr.ParkPowError(503, "Connection refused")
+        pair = fr.CameraPair(
             front="camera-front", rear="camera-rear", description="Gate 1"
         )
-        front_rear.camera_pairs = [pair]
+        fr.camera_pairs = [pair]
         old_time = time.time() - 20
         pair.front_event = create_camera_event(
             plate="OLD123", timestamp="2024-11-24T10:00:00Z", timestamp_unix=old_time
@@ -1613,7 +1611,7 @@ class TestOverwriteParkPowError:
                 "timestamp": "2024-11-24T10:00:20Z",
             },
         }
-        response, status = front_rear.process_request(webhook_data)
+        response, status = fr.process_request(webhook_data)
 
         # Main request continues with 202 buffered despite overwrite error
         assert status == 202
@@ -1629,21 +1627,21 @@ class TestShortHelper:
     """Test _short camera ID helper."""
 
     def test_short_none(self):
-        assert front_rear._short(None) == ""
+        assert h.shorten_id(None) == ""
 
     def test_short_empty(self):
-        assert front_rear._short("") == ""
+        assert h.shorten_id("") == ""
 
     def test_short_short_id(self):
-        assert front_rear._short("cam1") == "cam1"
+        assert h.shorten_id("cam1") == "cam1"
 
     def test_short_medium_id(self):
         camera_id = "a" * 59
-        assert front_rear._short(camera_id) == camera_id
+        assert h.shorten_id(camera_id) == camera_id
 
     def test_short_long_id(self):
         camera_id = "a" * 60
-        result = front_rear._short(camera_id)
+        result = h.shorten_id(camera_id)
         assert result.startswith("...")
         assert len(result) == 15  # "..." + 12 chars
 
@@ -1652,28 +1650,28 @@ class TestStreamResponse:
     """Test _stream_response helper."""
 
     def test_returns_message_and_status(self):
-        msg, status = front_rear._stream_response("test message", 200)
+        msg, status = h.stream_response("test message", 200)
         assert msg == "test message"
         assert status == 200
 
     def test_logs_error_for_5xx(self):
         with patch("protocols.front_rear.logging.error") as mock_log:
-            front_rear._stream_response("Server Error", 500)
+            h.stream_response("Server Error", 500)
             mock_log.assert_called_once()
 
     def test_logs_warning_for_4xx(self):
         with patch("protocols.front_rear.logging.warning") as mock_log:
-            front_rear._stream_response("Not Found", 404)
+            h.stream_response("Not Found", 404)
             mock_log.assert_called_once()
 
     def test_logs_info_for_2xx(self):
         with patch("protocols.front_rear.logging.info") as mock_log:
-            front_rear._stream_response("OK", 200)
+            h.stream_response("OK", 200)
             mock_log.assert_called_once()
 
     def test_includes_camera_id_in_log(self):
         with patch("protocols.front_rear.logging.info") as mock_log:
-            front_rear._stream_response("OK", 200, camera_id="cam1")
+            h.stream_response("OK", 200, camera_id="cam1")
             assert "cam1" in mock_log.call_args[0][0]
 
 
@@ -1681,13 +1679,13 @@ class TestParkPowErrorException:
     """Test ParkPowError exception class."""
 
     def test_attributes(self):
-        err = front_rear.ParkPowError(502, "Bad Gateway")
+        err = fr.ParkPowError(502, "Bad Gateway")
         assert err.status == 502
         assert err.message == "Bad Gateway"
         assert str(err) == "Bad Gateway"
 
     def test_is_exception(self):
-        err = front_rear.ParkPowError(500, "Internal")
+        err = fr.ParkPowError(500, "Internal")
         assert isinstance(err, Exception)
 
 
@@ -1710,7 +1708,7 @@ class TestInitializeValidation:
         monkeypatch.setenv("STREAM_API_TOKENS", "  ,  , ")
 
         with pytest.raises(ValueError, match="at least one valid token"):
-            front_rear.initialize()
+            fr.initialize()
 
     @patch("protocols.front_rear.asyncio.run_coroutine_threadsafe")
     @patch("protocols.front_rear.threading.Thread")
@@ -1728,7 +1726,7 @@ class TestInitializeValidation:
         monkeypatch.delenv("STREAM_API_TOKENS", raising=False)
 
         with pytest.raises(ValueError, match="STREAM_API_TOKENS"):
-            front_rear.initialize()
+            fr.initialize()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### https://trello.com/c/ffox9mRM

Also, the initial version was assuming the client would manage their middleware.
We are in fact managing it for them, so this changes how we want to report errors a bit.

| # | Trigger | `logging.*` level | Returned to Stream |
|---|---|---|---|
| 1 | Missing `Authorization` header | WARNING | `"FrontRear - Unauthorized: Missing Authorization header"`, 401 |
| 2 | Malformed token (bare `"Token"`/`"Bearer"`) | WARNING | `"FrontRear - Unauthorized: Malformed Authorization header"`, 401 |
| 3 | Invalid token | WARNING | `"FrontRear - Forbidden: Invalid token"`, 403 |
| 4 | Camera not in any configured pair | WARNING | `"FrontRear - Camera not configured in any pair"`, 404 |
| 5 | ParkPow visit rejected (low confidence scores) | ERROR | `"ParkPow - Visit rejected due to low confidence scores"`, 422 |
| 6 | ParkPow HTTP error (e.g. 401, 404, 500…) | ERROR | `"ParkPow - {ParkPow error message}"`, `{ParkPow status}` |
| 7 | ParkPow unreachable / connection error | ERROR | `"ParkPow - {error detail}"`, 503 |
| 8 | ParkPow async timeout (`asyncio.TimeoutError`) | ERROR | `"ParkPow - {error detail}"`, 503 |
| 9 | ParkPow sync timeout (`future.result` 15s) | ERROR | `"ParkPow - Timed out waiting for ParkPow response: ..."`, 503 |
| 10 | `_process_camera_pair` returns `None` (no visit ID) | WARNING | `"FrontRear - Internal error (null visit_id)"`, 424 |
| 11 | Camera pair processed successfully | INFO | `"FrontRear - Processed camera pair"`, 200 |
| 12 | Event buffered, waiting for paired camera | INFO | `"FrontRear - Event buffered, waiting for pair"`, 202 |

**Not returned to Stream** (overwrite path — processing continues regardless):
- ParkPow error during overwrite event processing → `ERROR` logged, `visit_id = None`, no Alert 4 sent, request continues normally to buffering/202.